### PR TITLE
Add `from-package` recovery mode to publish workflow

### DIFF
--- a/.github/workflows/chat-widget-publish.yml
+++ b/.github/workflows/chat-widget-publish.yml
@@ -6,12 +6,13 @@ on:
       version:
         required: true
         type: choice
-        description: Increment ChatWidget NPM version
+        description: Increment ChatWidget NPM version (use `from-package` to republish versions already committed in package.json without bumping)
         default: 'patch'
         options:
           - patch
           - minor
           - major
+          - from-package
 
 jobs:
   Publish:
@@ -47,7 +48,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RASABOT_PAT }}
         # `--force-publish` flag keeps versions consistent across our packages. Totally wild name for this kind of a flag :shrug:
+        # `from-package` is a recovery mode: it publishes whatever versions are already committed
+        # in each package.json but missing on npm, without bumping or creating a new tag/commit.
         run: |
           git config --global user.name "rasabot"
           git config --global user.email "rasabot@rasa.com"
-          npx lerna publish ${{ inputs.version }} --yes --force-publish
+          if [ "${{ inputs.version }}" = "from-package" ]; then
+            npx lerna publish from-package --yes
+          else
+            npx lerna publish ${{ inputs.version }} --yes --force-publish
+          fi


### PR DESCRIPTION
## Summary

Adds a fourth choice `from-package` to the `version` input of the **Chat Widget Publish** workflow. When selected, lerna is invoked as `lerna publish from-package --yes`, which republishes whatever is already committed in each `package.json` but missing on npm, **without** bumping versions, creating a commit, or pushing a new tag. The existing `patch | minor | major` flow is untouched.

## Why

The current workflow only knows how to bump-then-publish (`lerna publish <patch|minor|major>`). If a publish fails mid-flight (expired NPM_TOKEN, transient npm 5xx, etc.) lerna may have already created the bump commit and tag, and the next run will then fast-forward / `EBEHIND` itself into a no-op. There was no clean way to push the already-tagged versions onto npm without bumping again.

We're hitting exactly this case right now:

| Place | Version |
|---|---|
| `origin/main` (`lerna.json`, all three `package.json`) | `0.1.14` |
| Git tag | `v0.1.14` exists |
| npm `@rasahq/chat-widget-{sdk,ui,react}` latest | `0.1.12` |

After this PR is merged, running `Run workflow → from-package` will publish the already-committed `0.1.14` to npm without further bumping.

## Test plan

- [ ] Merge PR.
- [ ] Trigger **Actions → Chat Widget Publish → Run workflow**, pick `from-package`.
- [ ] Verify `npm view @rasahq/chat-widget-sdk@latest version` returns `0.1.14`.
- [ ] Verify no new commit or tag was pushed to `main`.
- [ ] On the next regular release, dispatch with `patch` and confirm the normal bump-and-publish flow still works.


Made with [Cursor](https://cursor.com)