### PR TITLE
Revert CSAT widget changes (rollback v0.1.16 to v0.1.15 code)

### DIFF
--- a/examples/html/index.html
+++ b/examples/html/index.html
@@ -15,11 +15,11 @@
   </head>
   <body>
     <rasa-chatbot-widget 
-      server-url="http://localhost:5005"
+      server-url="https://aiasistent.gov.rs"
       rest-enabled="true"
       enable-feedback="true"
-      feedback-question-text="How would you rate this conversation?"
-      feedback-thank-you-text="Thank you for your feedback!"
+      feedback-question-text="Како оцењујете овај разговор?"
+      feedback-thank-you-text="Хвала на повратним информацијама!"
     >
       <style>
         :root {

--- a/examples/react/feedback-example.tsx
+++ b/examples/react/feedback-example.tsx
@@ -66,9 +66,9 @@ const FeedbackExample: React.FC = () => {
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Configurable Messages:</strong> Custom question and thank you text</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Pattern-Based Triggering:</strong> Shows after specific message types</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Session Divider:</strong> Customizable "Session started" text</li>
-            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Custom Fonts:</strong> Configurable font family</li>
+            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Custom Fonts:</strong> OrtoRNIDS government font support</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Rasa Integration:</strong> Sends feedback as custom intent to set slots</li>
-            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Internationalization:</strong> Configurable text for any language/script</li>
+            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Internationalization:</strong> Serbian Cyrillic text support</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Responsive Design:</strong> Works on mobile and desktop</li>
           </ul>
         </div>
@@ -78,17 +78,17 @@ const FeedbackExample: React.FC = () => {
 
       {/* Complete Chat Widget with All Features */}
       <RasaChatbotWidget
-        serverUrl="http://localhost:5005"
-        inputMessagePlaceholder="What service are you interested in?"
-        widgetTitle="Rasa Assistant"
+        serverUrl="https://aiasistent.gov.rs"
+        inputMessagePlaceholder="Која Вас услуга занима?"
+        widgetTitle="еУправа асистент"
         widgetIcon=""
         initialPayload="/session_start"
         enableFeedback={true}
         feedbackTriggerPattern="text"
-        feedbackQuestionText="How would you rate this conversation?"
-        feedbackThankYouText="Thank you for your feedback!"
-        sessionStartedText="Session started:"
-        fontFamily="'Lato', sans-serif"
+        feedbackQuestionText="Како оцењујете овај разговор?"
+        feedbackThankYouText="Хвала на повратним информацијама!"
+        sessionStartedText="Сесија започета:"
+        fontFamily="'OrtoRNIDS', 'Lato', sans-serif"
         autoOpen={true}
         onChatWidgetFeedbackSubmitted={handleFeedbackSubmitted}
         onChatWidgetOpened={handleChatWidgetOpened}

--- a/packages/sdk/src/connection-strategy/HTTPConnection.utils.ts
+++ b/packages/sdk/src/connection-strategy/HTTPConnection.utils.ts
@@ -8,7 +8,6 @@ import {
   HttpTextResponse,
   HttpVideoResponse,
   HttpRatingResponse,
-  HttpCsatResponse,
 } from '../types/server-response.types';
 
 import { RESPONSE_MESSAGE_TYPES } from '../constants';
@@ -42,7 +41,7 @@ export function isHttpQuickReplyResponse(response: HttpResponse): response is Ht
 
 export function hasCustomAttribute(
   response: HttpResponse,
-): response is HttpCarouselResponse | HttpVideoResponse | HttpAccordionResponse | HttpFileDownloadResponse | HttpRatingResponse | HttpCsatResponse {
+): response is HttpCarouselResponse | HttpVideoResponse | HttpAccordionResponse | HttpFileDownloadResponse | HttpRatingResponse {
   return (
     'custom' in response &&
     response.custom !== undefined &&
@@ -50,8 +49,7 @@ export function hasCustomAttribute(
       response.custom.type === RESPONSE_MESSAGE_TYPES.VIDEO ||
       response.custom.type === RESPONSE_MESSAGE_TYPES.ACCORDION ||
       response.custom.type === RESPONSE_MESSAGE_TYPES.FILE_DOWNLOAD ||
-      response.custom.type === RESPONSE_MESSAGE_TYPES.RATING ||
-      response.custom.type === RESPONSE_MESSAGE_TYPES.CSAT) 
+      response.custom.type === RESPONSE_MESSAGE_TYPES.RATING) 
   );
 }
 

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -5,7 +5,6 @@ export const RESPONSE_MESSAGE_TYPES = {
   VIDEO: "video",
   IMAGE: "image",
   RATING: "rating",
-  CSAT: "csat",
 } as const;
 
 export const SESSION_STORAGE_KEYS = {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -129,16 +129,6 @@ export class Rasa extends EventEmitter {
     }
   }
 
-  /**
-   * Sends a payload to the channel without echoing it as a user message or
-   * persisting it to the chat history. Used for out-of-band signals such as
-   * CSAT feedback, where the user's selection should advance the conversation
-   * (e.g. fill the `csat_score` slot) but must not appear as a chat bubble.
-   */
-  public sendSilentMessage(payload: string): void {
-    this.connection.sendMessage(payload, this.sessionId);
-  }
-
   public reconnection(value: boolean): void {
     this.connection.reconnection(value);
   }

--- a/packages/sdk/src/message-parser/constants/message.constants.ts
+++ b/packages/sdk/src/message-parser/constants/message.constants.ts
@@ -8,5 +8,4 @@ export const MESSAGE_TYPES = {
   QUICK_REPLY: "quickReply",
   SESSION_DIVIDER: "sessionDivider",
   RATING: "rating",
-  CSAT: "csat",
 } as const;

--- a/packages/sdk/src/message-parser/types/parsed-message.types.ts
+++ b/packages/sdk/src/message-parser/types/parsed-message.types.ts
@@ -70,13 +70,6 @@ export interface RatingMessage extends BaseMessage {
   message: string;
 }
 
-export interface CsatMessage extends BaseMessage {
-  type: typeof MESSAGE_TYPES.CSAT;
-  question?: string;
-  thankYou?: string;
-  options?: { value: string; payload: string }[];
-}
-
 
 
 export type Message =
@@ -88,5 +81,4 @@ export type Message =
   | QuickReplyMessage
   | TextMessage
   | VideoMessage
-  | RatingMessage
-  | CsatMessage;
+  | RatingMessage;

--- a/packages/sdk/src/message-parser/utils/determine-message-type.ts
+++ b/packages/sdk/src/message-parser/utils/determine-message-type.ts
@@ -7,7 +7,6 @@ import {
   TextResponse,
   VideoResponse,
   RatingResponse,
-  CsatResponse,
 } from '../../types/server-response.types';
 import { CustomErrorClass, ErrorSeverity } from '../../errors';
 
@@ -22,7 +21,6 @@ const messageTypeMap = {
   quickReply: (msg: any): msg is QuickReplyResponse => msg?.quick_replies?.length > 0,
   fileDownload: (msg: any): msg is FileDownloadResponse => msg?.type === RESPONSE_MESSAGE_TYPES.FILE_DOWNLOAD,
   video: (msg: any): msg is VideoResponse => msg?.type === RESPONSE_MESSAGE_TYPES.VIDEO,
-  csat: (msg: any): msg is CsatResponse => msg?.type === RESPONSE_MESSAGE_TYPES.CSAT,
   text: (msg: any): msg is TextResponse => msg.text && msg.type === undefined,
   rating: (msg: any): msg is RatingResponse => msg?.type === RESPONSE_MESSAGE_TYPES.RATING,
 };

--- a/packages/sdk/src/message-parser/utils/message-parsers.ts
+++ b/packages/sdk/src/message-parser/utils/message-parsers.ts
@@ -7,7 +7,6 @@ import {
   TextMessage,
   VideoMessage,
   RatingMessage,
-  CsatMessage,
 } from '../types/parsed-message.types';
 import {
   AccordionResponse,
@@ -18,7 +17,6 @@ import {
   TextResponse,
   VideoResponse,
   RatingResponse,
-  CsatResponse,
 } from '../../types/server-response.types';
 
 import { MESSAGE_TYPES } from '../constants/message.constants';
@@ -94,17 +92,6 @@ export const MessageParsers = {
       payload: option.payload
     })),
     message: message.message,
-    timestamp: message.timestamp,
-  }),
-  csat: (message: CsatResponse, sender: SenderType): CsatMessage => ({
-    sender,
-    type: MESSAGE_TYPES.CSAT,
-    question: message.question,
-    thankYou: message.thank_you,
-    options: message.options?.map(option => ({
-      value: option.value,
-      payload: option.payload,
-    })),
     timestamp: message.timestamp,
   }),
 

--- a/packages/sdk/src/types/server-response.types.ts
+++ b/packages/sdk/src/types/server-response.types.ts
@@ -35,13 +35,6 @@ export interface RatingResponse extends BaseMessageResponse {
   message: string;
 }
 
-export interface CsatResponse extends BaseMessageResponse {
-  type: typeof RESPONSE_MESSAGE_TYPES.CSAT;
-  question?: string;
-  thank_you?: string;
-  options?: { value: string; payload: string }[];
-}
-
 export interface QuickReplyResponse extends BaseMessageResponse {
   text?: string;
   quick_replies: { content_type: string; payload: string; title: string; isSelected?: boolean }[];
@@ -101,11 +94,6 @@ export interface HttpRatingResponse extends BaseMessageResponse {
   custom: RatingResponse;
 }
 
-export interface HttpCsatResponse extends BaseMessageResponse {
-  recipient_id: string;
-  custom: CsatResponse;
-}
-
 export type HttpResponse =
   | HttpTextResponse
   | HttpImageResponse
@@ -114,8 +102,7 @@ export type HttpResponse =
   | HttpAccordionResponse
   | HttpFileDownloadResponse
   | HttpQuickReplyResponse
-  | HttpRatingResponse
-  | HttpCsatResponse;
+  | HttpRatingResponse;
 
 export type MessageResponse =
   | TextResponse
@@ -125,5 +112,4 @@ export type MessageResponse =
   | QuickReplyResponse
   | FileDownloadResponse
   | VideoResponse
-  | RatingResponse
-  | CsatResponse;
+  | RatingResponse;

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, Listen, Prop, State, Watch, h } from '@stencil/core/internal';
 import { v4 as uuidv4 } from 'uuid';
 
-import { MESSAGE_TYPES, Message, CsatMessage, QuickReply, QuickReplyMessage, Rasa, SENDER } from '@rasahq/chat-widget-sdk';
+import { MESSAGE_TYPES, Message, QuickReply, QuickReplyMessage, Rasa, SENDER } from '@rasahq/chat-widget-sdk';
 
 import { Messenger } from '../components/messenger';
 import { configStore, setConfigStore } from '../store/config-store';
@@ -34,18 +34,6 @@ export class RasaChatbotWidget {
   @State() isConnected = false;
   @State() showFeedback = false;
   @State() feedbackSubmitted = false;
-  @State() csatQuestion = '';
-  @State() csatThankYou = '';
-
-  /**
-   * Default payloads sent to the channel when the user picks a rating. These
-   * fill the CALM `csat_score` slot via the response-button `/SetSlots` syntax.
-   * A CSAT request from the bot can override these per-message.
-   */
-  private csatPayloads: { satisfied: string; unsatisfied: string } = {
-    satisfied: '/SetSlots{"csat_score": "satisfied"}',
-    unsatisfied: '/SetSlots{"csat_score": "unsatisfied"}',
-  };
 
   /**
    * Emitted when the Chat Widget is opened by the user
@@ -300,25 +288,6 @@ export class RasaChatbotWidget {
 
     this.messageDelayQueue = this.messageDelayQueue.then(() => {
       return new Promise<void>(resolve => {
-        // CSAT request: the bot is asking for a satisfaction rating
-        // (e.g. via pattern_customer_satisfaction). Don't render it as a chat
-        // bubble - trigger the thumbs feedback component instead.
-        if (data.type === MESSAGE_TYPES.CSAT) {
-          this.typingIndicator = false;
-          this.handleCsatRequest(data as CsatMessage);
-          resolve();
-          return;
-        }
-
-        // CSAT request sent as a standard buttons message (the bot's
-        // `utter_ask_csat_score` with `csat_score` button payloads). Intercept
-        // it so it renders as the thumbs popup instead of in-chat buttons.
-        if (this.enableFeedback && data.type === MESSAGE_TYPES.QUICK_REPLY && this.handleCsatButtons(data as QuickReplyMessage)) {
-          this.typingIndicator = false;
-          resolve();
-          return;
-        }
-
         // Check if this is a "no_feedback" message - if so, skip delay and clear typing indicator immediately
         const isNoFeedback = 'text' in data && data.text && (data.text as string).trim() === 'no_feedback';
         
@@ -336,6 +305,15 @@ export class RasaChatbotWidget {
           messageQueueService.enqueueMessage(data);
           this.typingIndicator = false;
           
+          // Show feedback after bot message is processed
+          if (this.enableFeedback && !this.showFeedback && !this.feedbackSubmitted && 
+              'sender' in data && data.sender === SENDER.BOT) {
+            // Add a delay to ensure the message is fully rendered and added to this.messages
+            setTimeout(() => {
+              this.showConversationFeedback();
+            }, 800);
+          }
+          
           // If senderID is configured and message was sent from this tab, broadcast event to share chat history with other tabs with same senderID 
           if (this.senderId && this.sentMessage) {
             debounce(() => {
@@ -348,75 +326,6 @@ export class RasaChatbotWidget {
       });
     });
   };
-
-  /**
-   * Activates the thumbs feedback component in response to a bot-driven CSAT
-   * request. The question and thank-you text default to the widget props but
-   * can be overridden per-request by the bot. Option payloads (sent to the
-   * channel on submit) can likewise be overridden by the bot.
-   */
-  private handleCsatRequest(message: CsatMessage): void {
-    // `enableFeedback` is the integrator's master opt-in for the CSAT UI. When
-    // disabled, the request is ignored (and never rendered as a chat bubble).
-    if (!this.enableFeedback) {
-      return;
-    }
-
-    const satisfied = message.options?.find(option => option.value === 'satisfied');
-    const unsatisfied = message.options?.find(option => option.value === 'unsatisfied');
-    this.csatPayloads = {
-      satisfied: satisfied?.payload || this.csatPayloads.satisfied,
-      unsatisfied: unsatisfied?.payload || this.csatPayloads.unsatisfied,
-    };
-    this.csatQuestion = message.question || this.feedbackQuestionText;
-    this.csatThankYou = message.thankYou || this.feedbackThankYouText;
-    this.feedbackSubmitted = false;
-    this.showFeedback = true;
-  }
-
-  /**
-   * Detects a standard buttons message that is actually a CSAT request (its
-   * button payloads set the `csat_score` slot, e.g. from the bot's
-   * `utter_ask_csat_score`). When matched, the thumbs popup is shown using the
-   * bot's own button payloads, and the buttons are NOT rendered in the chat.
-   * Returns true when handled as CSAT, false otherwise.
-   */
-  private handleCsatButtons(message: QuickReplyMessage): boolean {
-    if (!message.replies?.length) {
-      return false;
-    }
-
-    let satisfiedPayload: string | undefined;
-    let unsatisfiedPayload: string | undefined;
-    for (const reply of message.replies) {
-      const payload = reply.reply || '';
-      const haystack = `${payload} ${reply.text || ''}`.toLowerCase();
-      // Order matters: check the negative case first so "not satisfied" /
-      // "unsatisfied" / "dissatisfied" don't get caught by the "satisfied" check.
-      if (/unsatisf|dissatisf|not[_\s-]?satisf|negative/.test(haystack)) {
-        unsatisfiedPayload = payload;
-      } else if (/satisf|positive/.test(haystack)) {
-        satisfiedPayload = payload;
-      }
-    }
-
-    // Not a CSAT buttons message - let it render as normal quick replies.
-    if (!satisfiedPayload && !unsatisfiedPayload) {
-      return false;
-    }
-
-    this.csatPayloads = {
-      satisfied: satisfiedPayload || this.csatPayloads.satisfied,
-      unsatisfied: unsatisfiedPayload || this.csatPayloads.unsatisfied,
-    };
-    // Prefer the integrator's configured question/thank-you text; fall back to
-    // the bot's button-message text.
-    this.csatQuestion = this.feedbackQuestionText || message.text || '';
-    this.csatThankYou = this.feedbackThankYouText;
-    this.feedbackSubmitted = false;
-    this.showFeedback = true;
-    return true;
-  }
 
   private loadHistory = (data: Message[]): void => {
     this.messages = data;
@@ -510,15 +419,55 @@ export class RasaChatbotWidget {
     setTimeout(() => {
       this.showFeedback = false;
     }, 3500); // 3.5 seconds to allow thank you message to show and fade
-
-    // Send the rating to the bot through the normal channel so the active CSAT
-    // flow advances and the `csat_score` slot is filled. The payload is sent
-    // silently: it does not appear as a user message bubble in the chat.
-    const payload = this.csatPayloads[event.detail.rating];
-    if (payload) {
-      this.client.sendSilentMessage(payload);
-    }
-
+    
+    // Pass the rating through unchanged - it already matches the Rasa CALM
+    // `csat_score` slot's categorical values.
+    const slotValue = event.detail.rating;
+    
+    // Set slot directly in Rasa tracker via REST API (with better error handling)
+    (async () => {
+      try {
+        // Simple check - if serverUrl is not available, skip slot setting
+        if (!this.serverUrl) {
+          return;
+        }
+        
+        // Extract base URL from server URL (remove /webhooks/rest/webhook if present)
+        let baseUrl = this.serverUrl;
+        if (baseUrl.includes('/webhooks/rest/webhook')) {
+          baseUrl = baseUrl.replace('/webhooks/rest/webhook', '');
+        }
+        
+        // Get current session ID
+        const sessionId = this.client?.sessionId || 'default';
+        
+        // Set slot via Rasa tracker events API
+        const response = await fetch(`${baseUrl}/conversations/${sessionId}/tracker/events`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            // Add authentication headers if needed
+            // 'Authorization': 'Bearer your-token',
+            // 'X-Auth-Token': 'your-token',
+            // 'API-Key': 'your-api-key'
+          },
+          body: JSON.stringify({
+            "event": "slot",
+            "name": "csat_score",
+            "value": slotValue,
+            "timestamp": null
+          })
+        });
+        
+        // Slot setting response handled silently
+        if (!response.ok) {
+          // Slot setting failed - error handled silently
+        }
+      } catch (error) {
+        // Slot setting error handled silently
+      }
+    })();
+    
     // Emit the event safely
     try {
       if (this.chatWidgetFeedbackSubmitted && this.chatWidgetFeedbackSubmitted.emit) {
@@ -527,6 +476,27 @@ export class RasaChatbotWidget {
     } catch (error) {
       // Silently handle event emission errors
     }
+  }
+
+
+  private showConversationFeedback(): void {
+    if (!this.enableFeedback || this.messages.length === 0 || !this.feedbackQuestionText.trim()) {
+      return;
+    }
+
+    const lastMessage = this.messages[this.messages.length - 1];
+    
+    // Don't show feedback if the last message is "no_feedback"
+    if (lastMessage && 'text' in lastMessage && lastMessage.text && (lastMessage.text as string).trim() === 'no_feedback') {
+      return;
+    }
+
+    // Don't show feedback if the last message is a quick_reply (in the middle of a flow)
+    if (lastMessage && lastMessage.type === MESSAGE_TYPES.QUICK_REPLY) {
+      return;
+    }
+
+    this.showFeedback = true;
   }
 
   private getAltText() {
@@ -667,17 +637,17 @@ export class RasaChatbotWidget {
               isOpen={this.isOpen} 
               toggleFullScreenMode={this.toggleFullscreenMode} 
               isFullScreen={this.isFullScreen}
-              hasFeedback={this.showFeedback && this.isOpen}
+              hasFeedback={this.enableFeedback && this.isOpen}
             >
               {this.messageHistory.map((message, key) => this.renderMessage(message, true, key))}
               {this.cachedMessages}
               {this.typingIndicator && <rasa-typing-indicator></rasa-typing-indicator>}
-              {this.showFeedback && this.isOpen && (
+              {this.enableFeedback && this.isOpen && (
                 <rasa-conversation-feedback 
                   show={this.showFeedback}
                   submitted={this.feedbackSubmitted}
-                  questionText={this.csatQuestion}
-                  thankYouText={this.csatThankYou}
+                  questionText={this.feedbackQuestionText}
+                  thankYouText={this.feedbackThankYouText}
                   onFeedbackSubmitted={this.handleFeedbackSubmitted}
                 ></rasa-conversation-feedback>
               )}


### PR DESCRIPTION
## Summary

Reverts the CSAT score widget feature merged in #109. After merging, the next `patch` publish (v0.1.17) will ship the same code that was live in v0.1.15.

This is a `git revert -m 1` of the merge commit `6d21ac8`, so it leaves all surrounding history (including the v0.1.16 lerna bump commit and the v0.1.16 git tag) intact for an auditable trail.

## What changes
- Reverts every code change introduced by PR #109 (CSAT widget, message parser additions, examples, etc.)
- Leaves `lerna.json` / `package.json` versions at `0.1.16` so the next publish naturally bumps to `0.1.17`
- Diff vs `v0.1.15` is only the version strings (verified locally)

## Post-merge steps
1. Merge this PR into `main`
2. Run the **Chat Widget Publish** workflow with `version = patch` to publish **v0.1.17** containing v0.1.15's code

## Test plan
- [ ] CI passes (lint + build)
- [ ] After merge, run Publish workflow with `patch`
- [ ] Confirm `@rasahq/chat-widget-ui@0.1.17`, `@rasahq/chat-widget-sdk@0.1.17`, `@rasahq/chat-widget-react@0.1.17` are published
- [ ] Smoke-test the published version against an existing v0.1.15 consumer


Made with [Cursor](https://cursor.com)