### PR TITLE
Add CSAT score widget

### DIFF
--- a/examples/html/index.html
+++ b/examples/html/index.html
@@ -15,11 +15,11 @@
   </head>
   <body>
     <rasa-chatbot-widget 
-      server-url="https://aiasistent.gov.rs"
+      server-url="http://localhost:5005"
       rest-enabled="true"
       enable-feedback="true"
-      feedback-question-text="Како оцењујете овај разговор?"
-      feedback-thank-you-text="Хвала на повратним информацијама!"
+      feedback-question-text="How would you rate this conversation?"
+      feedback-thank-you-text="Thank you for your feedback!"
     >
       <style>
         :root {

--- a/examples/react/feedback-example.tsx
+++ b/examples/react/feedback-example.tsx
@@ -66,9 +66,9 @@ const FeedbackExample: React.FC = () => {
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Configurable Messages:</strong> Custom question and thank you text</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Pattern-Based Triggering:</strong> Shows after specific message types</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Session Divider:</strong> Customizable "Session started" text</li>
-            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Custom Fonts:</strong> OrtoRNIDS government font support</li>
+            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Custom Fonts:</strong> Configurable font family</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Rasa Integration:</strong> Sends feedback as custom intent to set slots</li>
-            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Internationalization:</strong> Serbian Cyrillic text support</li>
+            <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Internationalization:</strong> Configurable text for any language/script</li>
             <li style={{ margin: '5px 0', color: '#6c757d' }}>✅ <strong>Responsive Design:</strong> Works on mobile and desktop</li>
           </ul>
         </div>
@@ -78,17 +78,17 @@ const FeedbackExample: React.FC = () => {
 
       {/* Complete Chat Widget with All Features */}
       <RasaChatbotWidget
-        serverUrl="https://aiasistent.gov.rs"
-        inputMessagePlaceholder="Која Вас услуга занима?"
-        widgetTitle="еУправа асистент"
+        serverUrl="http://localhost:5005"
+        inputMessagePlaceholder="What service are you interested in?"
+        widgetTitle="Rasa Assistant"
         widgetIcon=""
         initialPayload="/session_start"
         enableFeedback={true}
         feedbackTriggerPattern="text"
-        feedbackQuestionText="Како оцењујете овај разговор?"
-        feedbackThankYouText="Хвала на повратним информацијама!"
-        sessionStartedText="Сесија започета:"
-        fontFamily="'OrtoRNIDS', 'Lato', sans-serif"
+        feedbackQuestionText="How would you rate this conversation?"
+        feedbackThankYouText="Thank you for your feedback!"
+        sessionStartedText="Session started:"
+        fontFamily="'Lato', sans-serif"
         autoOpen={true}
         onChatWidgetFeedbackSubmitted={handleFeedbackSubmitted}
         onChatWidgetOpened={handleChatWidgetOpened}

--- a/packages/sdk/src/connection-strategy/HTTPConnection.utils.ts
+++ b/packages/sdk/src/connection-strategy/HTTPConnection.utils.ts
@@ -8,6 +8,7 @@ import {
   HttpTextResponse,
   HttpVideoResponse,
   HttpRatingResponse,
+  HttpCsatResponse,
 } from '../types/server-response.types';
 
 import { RESPONSE_MESSAGE_TYPES } from '../constants';
@@ -41,7 +42,7 @@ export function isHttpQuickReplyResponse(response: HttpResponse): response is Ht
 
 export function hasCustomAttribute(
   response: HttpResponse,
-): response is HttpCarouselResponse | HttpVideoResponse | HttpAccordionResponse | HttpFileDownloadResponse | HttpRatingResponse {
+): response is HttpCarouselResponse | HttpVideoResponse | HttpAccordionResponse | HttpFileDownloadResponse | HttpRatingResponse | HttpCsatResponse {
   return (
     'custom' in response &&
     response.custom !== undefined &&
@@ -49,7 +50,8 @@ export function hasCustomAttribute(
       response.custom.type === RESPONSE_MESSAGE_TYPES.VIDEO ||
       response.custom.type === RESPONSE_MESSAGE_TYPES.ACCORDION ||
       response.custom.type === RESPONSE_MESSAGE_TYPES.FILE_DOWNLOAD ||
-      response.custom.type === RESPONSE_MESSAGE_TYPES.RATING) 
+      response.custom.type === RESPONSE_MESSAGE_TYPES.RATING ||
+      response.custom.type === RESPONSE_MESSAGE_TYPES.CSAT) 
   );
 }
 

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -5,6 +5,7 @@ export const RESPONSE_MESSAGE_TYPES = {
   VIDEO: "video",
   IMAGE: "image",
   RATING: "rating",
+  CSAT: "csat",
 } as const;
 
 export const SESSION_STORAGE_KEYS = {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -129,6 +129,16 @@ export class Rasa extends EventEmitter {
     }
   }
 
+  /**
+   * Sends a payload to the channel without echoing it as a user message or
+   * persisting it to the chat history. Used for out-of-band signals such as
+   * CSAT feedback, where the user's selection should advance the conversation
+   * (e.g. fill the `csat_score` slot) but must not appear as a chat bubble.
+   */
+  public sendSilentMessage(payload: string): void {
+    this.connection.sendMessage(payload, this.sessionId);
+  }
+
   public reconnection(value: boolean): void {
     this.connection.reconnection(value);
   }

--- a/packages/sdk/src/message-parser/constants/message.constants.ts
+++ b/packages/sdk/src/message-parser/constants/message.constants.ts
@@ -8,4 +8,5 @@ export const MESSAGE_TYPES = {
   QUICK_REPLY: "quickReply",
   SESSION_DIVIDER: "sessionDivider",
   RATING: "rating",
+  CSAT: "csat",
 } as const;

--- a/packages/sdk/src/message-parser/types/parsed-message.types.ts
+++ b/packages/sdk/src/message-parser/types/parsed-message.types.ts
@@ -70,6 +70,13 @@ export interface RatingMessage extends BaseMessage {
   message: string;
 }
 
+export interface CsatMessage extends BaseMessage {
+  type: typeof MESSAGE_TYPES.CSAT;
+  question?: string;
+  thankYou?: string;
+  options?: { value: string; payload: string }[];
+}
+
 
 
 export type Message =
@@ -81,4 +88,5 @@ export type Message =
   | QuickReplyMessage
   | TextMessage
   | VideoMessage
-  | RatingMessage;
+  | RatingMessage
+  | CsatMessage;

--- a/packages/sdk/src/message-parser/utils/determine-message-type.ts
+++ b/packages/sdk/src/message-parser/utils/determine-message-type.ts
@@ -7,6 +7,7 @@ import {
   TextResponse,
   VideoResponse,
   RatingResponse,
+  CsatResponse,
 } from '../../types/server-response.types';
 import { CustomErrorClass, ErrorSeverity } from '../../errors';
 
@@ -21,6 +22,7 @@ const messageTypeMap = {
   quickReply: (msg: any): msg is QuickReplyResponse => msg?.quick_replies?.length > 0,
   fileDownload: (msg: any): msg is FileDownloadResponse => msg?.type === RESPONSE_MESSAGE_TYPES.FILE_DOWNLOAD,
   video: (msg: any): msg is VideoResponse => msg?.type === RESPONSE_MESSAGE_TYPES.VIDEO,
+  csat: (msg: any): msg is CsatResponse => msg?.type === RESPONSE_MESSAGE_TYPES.CSAT,
   text: (msg: any): msg is TextResponse => msg.text && msg.type === undefined,
   rating: (msg: any): msg is RatingResponse => msg?.type === RESPONSE_MESSAGE_TYPES.RATING,
 };

--- a/packages/sdk/src/message-parser/utils/message-parsers.ts
+++ b/packages/sdk/src/message-parser/utils/message-parsers.ts
@@ -7,6 +7,7 @@ import {
   TextMessage,
   VideoMessage,
   RatingMessage,
+  CsatMessage,
 } from '../types/parsed-message.types';
 import {
   AccordionResponse,
@@ -17,6 +18,7 @@ import {
   TextResponse,
   VideoResponse,
   RatingResponse,
+  CsatResponse,
 } from '../../types/server-response.types';
 
 import { MESSAGE_TYPES } from '../constants/message.constants';
@@ -92,6 +94,17 @@ export const MessageParsers = {
       payload: option.payload
     })),
     message: message.message,
+    timestamp: message.timestamp,
+  }),
+  csat: (message: CsatResponse, sender: SenderType): CsatMessage => ({
+    sender,
+    type: MESSAGE_TYPES.CSAT,
+    question: message.question,
+    thankYou: message.thank_you,
+    options: message.options?.map(option => ({
+      value: option.value,
+      payload: option.payload,
+    })),
     timestamp: message.timestamp,
   }),
 

--- a/packages/sdk/src/types/server-response.types.ts
+++ b/packages/sdk/src/types/server-response.types.ts
@@ -35,6 +35,13 @@ export interface RatingResponse extends BaseMessageResponse {
   message: string;
 }
 
+export interface CsatResponse extends BaseMessageResponse {
+  type: typeof RESPONSE_MESSAGE_TYPES.CSAT;
+  question?: string;
+  thank_you?: string;
+  options?: { value: string; payload: string }[];
+}
+
 export interface QuickReplyResponse extends BaseMessageResponse {
   text?: string;
   quick_replies: { content_type: string; payload: string; title: string; isSelected?: boolean }[];
@@ -94,6 +101,11 @@ export interface HttpRatingResponse extends BaseMessageResponse {
   custom: RatingResponse;
 }
 
+export interface HttpCsatResponse extends BaseMessageResponse {
+  recipient_id: string;
+  custom: CsatResponse;
+}
+
 export type HttpResponse =
   | HttpTextResponse
   | HttpImageResponse
@@ -102,7 +114,8 @@ export type HttpResponse =
   | HttpAccordionResponse
   | HttpFileDownloadResponse
   | HttpQuickReplyResponse
-  | HttpRatingResponse;
+  | HttpRatingResponse
+  | HttpCsatResponse;
 
 export type MessageResponse =
   | TextResponse
@@ -112,4 +125,5 @@ export type MessageResponse =
   | QuickReplyResponse
   | FileDownloadResponse
   | VideoResponse
-  | RatingResponse;
+  | RatingResponse
+  | CsatResponse;

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.scss
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.scss
@@ -1,14 +1,27 @@
-.rasa-conversation-feedback {
+// Take the host element out of the parent's flex flow. Otherwise the
+// `<rasa-conversation-feedback>` custom element sits as a flex child of
+// `.messenger__content` (which is `display: flex; gap: 24px`) and reserves a
+// 24px `gap` slot before itself. When the popup later unmounts, that gap
+// disappears in one frame and the chat content visibly drops 24px - which
+// reads as the "quick drop at the end" of the slide-down animation, even
+// though the padding transition itself is perfectly linear. Making the host
+// absolutely-positioned removes it from layout entirely, so unmount is a
+// pure compositor operation with no layout shift.
+:host {
   position: absolute;
   bottom: 80px;
   left: 0;
   right: 0;
+  z-index: 10;
+}
+
+.rasa-conversation-feedback {
+  position: relative;
   padding: 10px 16px 12px 16px;
   margin: 0;
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(8px);
   border-top: 1px solid rgba(0, 0, 0, 0.1);
-  z-index: 10;
   
   // Smooth animations - slower and more elegant
   animation: fadeInUp 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -19,19 +32,6 @@
     border-top: none;
     background: transparent;
     backdrop-filter: none;
-  }
-
-  // Fade-out: pure opacity, no transform. An earlier version slid the popup
-  // downward + scaled it, which read as the thank-you "dropping" into the
-  // chat input area - jarring rather than graceful. A plain opacity fade is
-  // what an info banner naturally wants.
-  // `forwards` is critical: without it the element snaps back to opacity 1
-  // when the animation ends, producing a flicker right before unmount.
-  // `pointer-events: none` prevents the thumbs from being clickable during
-  // the fade.
-  &--fading-out {
-    animation: feedbackFadeOut 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
-    pointer-events: none;
   }
 
       &__content {
@@ -125,7 +125,15 @@
     }
   }
 
-      // Thank you message styling - elegant and professional
+      // Thank you message styling - elegant and professional.
+      //
+      // The fade-out is driven entirely by CSS via an animation list: first
+      // `thankYouFadeIn` (0.5s, no delay), then `feedbackFadeOut` (0.6s,
+      // delayed by 1.5s = THANK_YOU_HOLD_MS). `forwards` keeps the element
+      // at opacity 0 once the fade completes, until the parent unmounts it.
+      // Driving this from CSS removes the need for a JS setTimeout in the
+      // component, which previously had to be cancelled in
+      // disconnectedCallback to avoid setting state on a detached instance.
       &__thank-you {
         position: absolute;
         top: 0;
@@ -137,8 +145,11 @@
         justify-content: center;
         background: transparent;
         border-radius: 0;
-        animation: thankYouFadeIn 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        animation:
+          thankYouFadeIn 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+          feedbackFadeOut 0.6s 1.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
         z-index: 20;
+        pointer-events: none;
       }
 
       &__thank-you-content {

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.scss
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.scss
@@ -21,15 +21,17 @@
     backdrop-filter: none;
   }
 
-  // Fade-out animation - smooth and elegant
+  // Fade-out: pure opacity, no transform. An earlier version slid the popup
+  // downward + scaled it, which read as the thank-you "dropping" into the
+  // chat input area - jarring rather than graceful. A plain opacity fade is
+  // what an info banner naturally wants.
+  // `forwards` is critical: without it the element snaps back to opacity 1
+  // when the animation ends, producing a flicker right before unmount.
+  // `pointer-events: none` prevents the thumbs from being clickable during
+  // the fade.
   &--fading-out {
-    animation: fadeOutDown 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-    // Remove from document flow during fade-out so content moves up
-    position: absolute !important;
-    bottom: 80px !important;
-    left: 0 !important;
-    right: 0 !important;
-    z-index: 10 !important;
+    animation: feedbackFadeOut 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    pointer-events: none;
   }
 
       &__content {
@@ -176,29 +178,16 @@
   }
 }
 
-@keyframes fadeOutDown {
+@keyframes feedbackFadeOut {
   0% {
     opacity: 1;
-    transform: translateY(0) scale(1);
   }
   100% {
     opacity: 0;
-    transform: translateY(10px) scale(0.98);
   }
 }
 
 // Thank you message animations
-@keyframes thankYouFadeIn {
-  0% {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
 @keyframes thankYouFadeIn {
   0% {
     opacity: 0;

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.test.tsx
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.test.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { RasaConversationFeedback } from './conversation-feedback';
+import { CONVERSATION_FEEDBACK_TIMINGS } from './conversation-feedback.timings';
 
 describe('rasa-conversation-feedback', () => {
   it('renders feedback component when show is true and questionText is provided', async () => {
@@ -82,6 +83,88 @@ describe('rasa-conversation-feedback', () => {
     expect(feedbackSubmittedSpy.mock.calls[0][0].detail).toEqual({
       rating: 'unsatisfied',
       helpful: true
+    });
+  });
+
+  describe('graceful fade-out', () => {
+    // These tests deliberately avoid jest.useFakeTimers() because Stencil's
+    // newSpecPage relies on real timers for its initial render. The fade
+    // trigger is exercised by flipping the component's `isFadingOut` state
+    // directly - which is exactly what the production setTimeout would do
+    // after THANK_YOU_HOLD_MS elapses.
+
+    it('emits the rating event synchronously on click (no visual delay)', async () => {
+      const page = await newSpecPage({
+        components: [RasaConversationFeedback],
+        html: `<rasa-conversation-feedback show="true" question-text="Rate me?" thank-you-text="Thanks!"></rasa-conversation-feedback>`,
+      });
+
+      const spy = jest.fn();
+      page.win.addEventListener('feedbackSubmitted', spy);
+
+      (page.root.shadowRoot.querySelector('.rasa-conversation-feedback__thumb--positive') as HTMLElement).click();
+
+      // No waitForChanges, no timers: the event must already have fired.
+      // Parent's setCsatAnswered relies on this synchronous emit so a refresh
+      // immediately after click cannot race the answered hash being persisted.
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the thank-you mounted with the fade-out class so CSS can animate it', async () => {
+      const page = await newSpecPage({
+        components: [RasaConversationFeedback],
+        html: `<rasa-conversation-feedback show="true" question-text="Rate me?" thank-you-text="Thanks!"></rasa-conversation-feedback>`,
+      });
+
+      (page.root.shadowRoot.querySelector('.rasa-conversation-feedback__thumb--positive') as HTMLElement).click();
+      await page.waitForChanges();
+
+      // Mid-hold: thank-you visible, no fade-out class.
+      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback__thank-you')).toBeTruthy();
+      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback--fading-out')).toBeFalsy();
+
+      // Simulate the THANK_YOU_HOLD_MS timer elapsing. The host must STILL
+      // render (so the CSS fade-out animation can play out) with the
+      // --fading-out class applied. Returning null here was the original bug
+      // that caused the abrupt disappearance the PR feedback flagged.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (page.rootInstance as any).isFadingOut = true;
+      await page.waitForChanges();
+
+      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback')).toBeTruthy();
+      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback--fading-out')).toBeTruthy();
+      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback__thank-you')).toBeTruthy();
+    });
+
+    it('exposes a coherent set of dismiss timings', () => {
+      // Guards the contract the parent widget relies on for its unmount delay.
+      expect(CONVERSATION_FEEDBACK_TIMINGS.TOTAL_DISMISS_MS).toBe(
+        CONVERSATION_FEEDBACK_TIMINGS.THANK_YOU_HOLD_MS + CONVERSATION_FEEDBACK_TIMINGS.FADE_OUT_MS,
+      );
+      // Snappy dismissal is the whole point of this fix - keep it under 2.5s.
+      expect(CONVERSATION_FEEDBACK_TIMINGS.TOTAL_DISMISS_MS).toBeLessThanOrEqual(2500);
+    });
+
+    it('ignores a second click after a rating has been selected', async () => {
+      const page = await newSpecPage({
+        components: [RasaConversationFeedback],
+        html: `<rasa-conversation-feedback show="true" question-text="Rate me?"></rasa-conversation-feedback>`,
+      });
+
+      const spy = jest.fn();
+      page.win.addEventListener('feedbackSubmitted', spy);
+
+      // Call the handler directly twice to bypass the disabled attribute the
+      // buttons get after the first click. The handler itself must guard
+      // against re-entry so a stray programmatic call cannot emit twice.
+      const instance = page.rootInstance as RasaConversationFeedback;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (instance as any).handleRatingClick('satisfied');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (instance as any).handleRatingClick('unsatisfied');
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0].detail.rating).toBe('satisfied');
     });
   });
 });

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.test.tsx
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.test.tsx
@@ -87,11 +87,13 @@ describe('rasa-conversation-feedback', () => {
   });
 
   describe('graceful fade-out', () => {
-    // These tests deliberately avoid jest.useFakeTimers() because Stencil's
-    // newSpecPage relies on real timers for its initial render. The fade
-    // trigger is exercised by flipping the component's `isFadingOut` state
-    // directly - which is exactly what the production setTimeout would do
-    // after THANK_YOU_HOLD_MS elapses.
+    // The fade-out is now driven entirely by CSS (a chained `fadeIn` +
+    // delayed `fadeOut` animation with `forwards` fill mode on the
+    // thank-you element). The component itself no longer schedules any
+    // setTimeout for the dismiss - these tests verify the bits that remain
+    // the component's responsibility: synchronous event emit, the
+    // thank-you element being mounted so CSS can animate it, and the
+    // click-once guard.
 
     it('emits the rating event synchronously on click (no visual delay)', async () => {
       const page = await newSpecPage({
@@ -110,7 +112,7 @@ describe('rasa-conversation-feedback', () => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
-    it('keeps the thank-you mounted with the fade-out class so CSS can animate it', async () => {
+    it('mounts the thank-you element so the CSS fade-out animation can play', async () => {
       const page = await newSpecPage({
         components: [RasaConversationFeedback],
         html: `<rasa-conversation-feedback show="true" question-text="Rate me?" thank-you-text="Thanks!"></rasa-conversation-feedback>`,
@@ -119,20 +121,14 @@ describe('rasa-conversation-feedback', () => {
       (page.root.shadowRoot.querySelector('.rasa-conversation-feedback__thumb--positive') as HTMLElement).click();
       await page.waitForChanges();
 
-      // Mid-hold: thank-you visible, no fade-out class.
-      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback__thank-you')).toBeTruthy();
-      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback--fading-out')).toBeFalsy();
-
-      // Simulate the THANK_YOU_HOLD_MS timer elapsing. The host must STILL
-      // render (so the CSS fade-out animation can play out) with the
-      // --fading-out class applied. Returning null here was the original bug
-      // that caused the abrupt disappearance the PR feedback flagged.
-      (page.rootInstance as unknown as { isFadingOut: boolean }).isFadingOut = true;
-      await page.waitForChanges();
-
+      // After the click the thank-you element is present and the rating
+      // buttons have been swapped out. The fade-out itself is a CSS-only
+      // animation on the thank-you element (see conversation-feedback.scss),
+      // so we only need to verify the element is in the DOM here - the
+      // animation runs without any state change from the component.
       expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback')).toBeTruthy();
-      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback--fading-out')).toBeTruthy();
       expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback__thank-you')).toBeTruthy();
+      expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback__rating')).toBeFalsy();
     });
 
     it('exposes a coherent set of dismiss timings', () => {

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.test.tsx
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.test.tsx
@@ -127,8 +127,7 @@ describe('rasa-conversation-feedback', () => {
       // render (so the CSS fade-out animation can play out) with the
       // --fading-out class applied. Returning null here was the original bug
       // that caused the abrupt disappearance the PR feedback flagged.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (page.rootInstance as any).isFadingOut = true;
+      (page.rootInstance as unknown as { isFadingOut: boolean }).isFadingOut = true;
       await page.waitForChanges();
 
       expect(page.root.shadowRoot.querySelector('.rasa-conversation-feedback')).toBeTruthy();
@@ -157,11 +156,11 @@ describe('rasa-conversation-feedback', () => {
       // Call the handler directly twice to bypass the disabled attribute the
       // buttons get after the first click. The handler itself must guard
       // against re-entry so a stray programmatic call cannot emit twice.
-      const instance = page.rootInstance as RasaConversationFeedback;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (instance as any).handleRatingClick('satisfied');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (instance as any).handleRatingClick('unsatisfied');
+      const instance = page.rootInstance as unknown as {
+        handleRatingClick: (rating: 'satisfied' | 'unsatisfied') => void;
+      };
+      instance.handleRatingClick('satisfied');
+      instance.handleRatingClick('unsatisfied');
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy.mock.calls[0][0].detail.rating).toBe('satisfied');

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.timings.ts
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.timings.ts
@@ -1,0 +1,21 @@
+/**
+ * Timing knobs for the dismissal of the conversation-feedback popup after a
+ * rating is submitted. Kept in a sibling file (not inside the @Component
+ * module) because Stencil requires component files to export only their
+ * component class.
+ *
+ * Total time the popup stays on screen after the click =
+ *   THANK_YOU_HOLD_MS + FADE_OUT_MS
+ *
+ * Kept intentionally short (~2s) so the popup feels snappy and so a refresh
+ * shortly after rating cannot show it again. FADE_OUT_MS must stay in sync
+ * with the `--fading-out` rule in conversation-feedback.scss.
+ */
+export const THANK_YOU_HOLD_MS = 1500;
+export const FADE_OUT_MS = 600;
+
+export const CONVERSATION_FEEDBACK_TIMINGS = {
+  THANK_YOU_HOLD_MS,
+  FADE_OUT_MS,
+  TOTAL_DISMISS_MS: THANK_YOU_HOLD_MS + FADE_OUT_MS,
+};

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.timings.ts
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.timings.ts
@@ -7,9 +7,14 @@
  * Total time the popup stays on screen after the click =
  *   THANK_YOU_HOLD_MS + FADE_OUT_MS
  *
+ * The visual fade-out is driven by CSS now (see the `&__thank-you` rule in
+ * conversation-feedback.scss): a chained `fadeIn` + delayed `fadeOut`
+ * animation on the thank-you element. These constants exist only so the
+ * parent widget can compute when to unmount the popup after the animation
+ * has settled - they must stay in sync with the SCSS hold / fade durations.
+ *
  * Kept intentionally short (~2s) so the popup feels snappy and so a refresh
- * shortly after rating cannot show it again. FADE_OUT_MS must stay in sync
- * with the `--fading-out` rule in conversation-feedback.scss.
+ * shortly after rating cannot show it again.
  */
 export const THANK_YOU_HOLD_MS = 1500;
 export const FADE_OUT_MS = 600;

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.tsx
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.tsx
@@ -1,5 +1,6 @@
 import { Component, Prop, Event, EventEmitter, h, State } from '@stencil/core';
 import { feedbackIcons } from './icons';
+import { THANK_YOU_HOLD_MS } from './conversation-feedback.timings';
 
 @Component({
   tag: 'rasa-conversation-feedback',
@@ -53,28 +54,53 @@ export class RasaConversationFeedback {
    */
   @State() showThankYou: boolean = false;
 
+  /**
+   * Tracks the pending fade-out timer so we can cancel it if the host
+   * unmounts the popup before the hold elapses (e.g. the user sends a new
+   * message and the parent flips `showFeedback = false`). Without this the
+   * timer would later fire against a disposed component and set state on a
+   * detached instance.
+   */
+  private fadeOutTimer: ReturnType<typeof setTimeout> | null = null;
+
+  disconnectedCallback() {
+    if (this.fadeOutTimer !== null) {
+      clearTimeout(this.fadeOutTimer);
+      this.fadeOutTimer = null;
+    }
+  }
+
   private handleRatingClick(rating: 'satisfied' | 'unsatisfied') {
+    // Guard against double-clicks: a second click on the other thumb (or the
+    // same one) after a selection is already locked in must be a no-op.
+    if (this.selectedRating !== null) return;
+
     this.selectedRating = rating;
-    
-    // Show thank you message immediately (no delay)
     this.showThankYou = true;
-    
-    // Hide thank you message after 3 seconds and set fading out
-    setTimeout(() => {
-      this.showThankYou = false;
-      this.isFadingOut = true;
-    }, 3000);
-    
-    // Emit feedback immediately - main widget will handle timing
+
+    // Emit synchronously so the parent persists the answered state before any
+    // visual delay - protects against a refresh that races the fade-out.
     this.feedbackSubmitted.emit({
-      rating: rating,
-      helpful: true // Default to helpful when just rating
+      rating,
+      helpful: true,
     });
+
+    // Hold the thank-you, then trigger the CSS fade-out. We deliberately keep
+    // `showThankYou` true here so the thank-you content stays mounted (and
+    // visible) while it fades; previously we flipped it to false alongside
+    // `isFadingOut`, which collapsed the content before the animation ran.
+    this.fadeOutTimer = setTimeout(() => {
+      this.fadeOutTimer = null;
+      this.isFadingOut = true;
+    }, THANK_YOU_HOLD_MS);
   }
 
 
   render() {
-    if (!this.show || this.isFadingOut || !this.questionText.trim()) {
+    // Note: do NOT short-circuit on `isFadingOut`. Returning null here would
+    // remove the element from the DOM before the CSS fade-out has a chance to
+    // play, producing the abrupt disappearance the PR feedback called out.
+    if (!this.show || !this.questionText.trim()) {
       return null;
     }
 

--- a/packages/ui/src/components/conversation-feedback/conversation-feedback.tsx
+++ b/packages/ui/src/components/conversation-feedback/conversation-feedback.tsx
@@ -1,6 +1,5 @@
 import { Component, Prop, Event, EventEmitter, h, State } from '@stencil/core';
 import { feedbackIcons } from './icons';
-import { THANK_YOU_HOLD_MS } from './conversation-feedback.timings';
 
 @Component({
   tag: 'rasa-conversation-feedback',
@@ -45,30 +44,9 @@ export class RasaConversationFeedback {
   @State() isHelpful: boolean | null = null;
 
   /**
-   * State to track if component is fading out
-   */
-  @State() isFadingOut: boolean = false;
-
-  /**
    * State to track if thank you message is showing
    */
   @State() showThankYou: boolean = false;
-
-  /**
-   * Tracks the pending fade-out timer so we can cancel it if the host
-   * unmounts the popup before the hold elapses (e.g. the user sends a new
-   * message and the parent flips `showFeedback = false`). Without this the
-   * timer would later fire against a disposed component and set state on a
-   * detached instance.
-   */
-  private fadeOutTimer: ReturnType<typeof setTimeout> | null = null;
-
-  disconnectedCallback() {
-    if (this.fadeOutTimer !== null) {
-      clearTimeout(this.fadeOutTimer);
-      this.fadeOutTimer = null;
-    }
-  }
 
   private handleRatingClick(rating: 'satisfied' | 'unsatisfied') {
     // Guard against double-clicks: a second click on the other thumb (or the
@@ -85,30 +63,23 @@ export class RasaConversationFeedback {
       helpful: true,
     });
 
-    // Hold the thank-you, then trigger the CSS fade-out. We deliberately keep
-    // `showThankYou` true here so the thank-you content stays mounted (and
-    // visible) while it fades; previously we flipped it to false alongside
-    // `isFadingOut`, which collapsed the content before the animation ran.
-    this.fadeOutTimer = setTimeout(() => {
-      this.fadeOutTimer = null;
-      this.isFadingOut = true;
-    }, THANK_YOU_HOLD_MS);
+    // No JS timer for the fade-out: the thank-you element's CSS animation
+    // is a chained `fadeIn` + delayed `fadeOut` with `forwards` fill, so
+    // the popup self-dismisses visually without any setTimeout here. The
+    // parent's slide-down + unmount run on the same CSS timeline.
   }
 
 
   render() {
-    // Note: do NOT short-circuit on `isFadingOut`. Returning null here would
-    // remove the element from the DOM before the CSS fade-out has a chance to
-    // play, producing the abrupt disappearance the PR feedback called out.
+    // Note: do NOT short-circuit while the popup is fading out. The popup
+    // stays mounted with its `forwards`-filled CSS fade-out animation - the
+    // parent unmounts it via a single setTimeout once the chat slide is done.
     if (!this.show || !this.questionText.trim()) {
       return null;
     }
 
     return (
-      <div class={{
-        'rasa-conversation-feedback': true,
-        'rasa-conversation-feedback--fading-out': this.isFadingOut
-      }}>
+      <div class="rasa-conversation-feedback">
         <div class="rasa-conversation-feedback__content">
           {!this.showThankYou ? (
             <div>

--- a/packages/ui/src/components/messenger.tsx
+++ b/packages/ui/src/components/messenger.tsx
@@ -7,17 +7,26 @@ type MessengerProps = {
   isFullScreen: boolean;
   toggleFullScreenMode: () => void;
   hasFeedback?: boolean;
+  isFeedbackDismissing?: boolean;
 };
 
-export const Messenger: FunctionalComponent<MessengerProps> = ({ isOpen, isFullScreen, toggleFullScreenMode, hasFeedback }, children) => {
+export const Messenger: FunctionalComponent<MessengerProps> = (
+  { isOpen, isFullScreen, toggleFullScreenMode, hasFeedback, isFeedbackDismissing },
+  children
+) => {
   const Icon = isFullScreen ? 'rasa-icon-arrows-contract' : 'rasa-icon-arrows-expand';
 
   return (
-    <div class={{ 
-      'messenger': true, 
-      'messenger--fullscreen': isFullScreen, 
+    <div class={{
+      'messenger': true,
+      'messenger--fullscreen': isFullScreen,
       'messenger--open': isOpen,
-      'messenger--with-feedback': hasFeedback
+      'messenger--with-feedback': hasFeedback,
+      // Only present during the dismiss-down animation. The padding-bottom
+      // transition is gated on this class so the popup's *entrance* (when
+      // `--with-feedback` is added) makes room instantly, while the
+      // *dismissal* slides smoothly in lock-step with the popup fade.
+      'messenger--feedback-dismissing': isFeedbackDismissing,
     }}>
       <div class="messenger__header">
         <div>

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.loadHistory.test.tsx
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.loadHistory.test.tsx
@@ -11,7 +11,13 @@
  *      template in a fresh conversation, the popup opens again.
  */
 import { newSpecPage } from '@stencil/core/testing';
-import { MESSAGE_TYPES, Message, SENDER } from '@rasahq/chat-widget-sdk';
+import {
+  CsatMessage,
+  MESSAGE_TYPES,
+  Message,
+  QuickReplyMessage,
+  SENDER,
+} from '@rasahq/chat-widget-sdk';
 import { RasaChatbotWidget } from './rasa-chatbot-widget';
 
 const divider = (): Message =>
@@ -20,7 +26,7 @@ const divider = (): Message =>
 const text = (sender: 'bot' | 'user' = SENDER.BOT, body = 'hi'): Message =>
   ({ sender, type: MESSAGE_TYPES.TEXT, text: body } as Message);
 
-const csatButtons = (question = 'Was this helpful?'): Message =>
+const csatButtons = (question = 'Was this helpful?'): QuickReplyMessage =>
   ({
     sender: SENDER.BOT,
     type: MESSAGE_TYPES.QUICK_REPLY,
@@ -29,9 +35,9 @@ const csatButtons = (question = 'Was this helpful?'): Message =>
       { text: 'Yes', reply: '/SetSlots{"csat_score":"satisfied"}', isSelected: false },
       { text: 'No', reply: '/SetSlots{"csat_score":"unsatisfied"}', isSelected: false },
     ],
-  } as unknown as Message);
+  } as unknown as QuickReplyMessage);
 
-const csatTyped = (question = 'Was this helpful?'): Message =>
+const csatTyped = (question = 'Was this helpful?'): CsatMessage =>
   ({
     sender: SENDER.BOT,
     type: MESSAGE_TYPES.CSAT,
@@ -41,7 +47,7 @@ const csatTyped = (question = 'Was this helpful?'): Message =>
       { value: 'satisfied', payload: '/SetSlots{"csat_score":"satisfied"}' },
       { value: 'unsatisfied', payload: '/SetSlots{"csat_score":"unsatisfied"}' },
     ],
-  } as unknown as Message);
+  } as unknown as CsatMessage);
 
 /**
  * Render the widget without letting it construct a real Rasa client.

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.loadHistory.test.tsx
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.loadHistory.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * Integration tests for `RasaChatbotWidget.loadHistory` and the
+ * cross-session CSAT lifecycle.
+ *
+ * Spec:
+ *   1. CSAT prompts in history are NEVER rendered as chat bubbles.
+ *   2. A page refresh ALWAYS closes the popup, whether the user rated or
+ *      not - a pending CSAT request expires with its session.
+ *   3. After a refresh, the answered-hash is dropped on the next
+ *      session-divider, so when the bot reuses the same `utter_ask_csat_score`
+ *      template in a fresh conversation, the popup opens again.
+ */
+import { newSpecPage } from '@stencil/core/testing';
+import { MESSAGE_TYPES, Message, SENDER } from '@rasahq/chat-widget-sdk';
+import { RasaChatbotWidget } from './rasa-chatbot-widget';
+
+const divider = (): Message =>
+  ({ type: MESSAGE_TYPES.SESSION_DIVIDER, startDate: new Date() } as Message);
+
+const text = (sender: 'bot' | 'user' = SENDER.BOT, body = 'hi'): Message =>
+  ({ sender, type: MESSAGE_TYPES.TEXT, text: body } as Message);
+
+const csatButtons = (question = 'Was this helpful?'): Message =>
+  ({
+    sender: SENDER.BOT,
+    type: MESSAGE_TYPES.QUICK_REPLY,
+    text: question,
+    replies: [
+      { text: 'Yes', reply: '/SetSlots{"csat_score":"satisfied"}', isSelected: false },
+      { text: 'No', reply: '/SetSlots{"csat_score":"unsatisfied"}', isSelected: false },
+    ],
+  } as unknown as Message);
+
+const csatTyped = (question = 'Was this helpful?'): Message =>
+  ({
+    sender: SENDER.BOT,
+    type: MESSAGE_TYPES.CSAT,
+    question,
+    thankYou: 'Thanks!',
+    options: [
+      { value: 'satisfied', payload: '/SetSlots{"csat_score":"satisfied"}' },
+      { value: 'unsatisfied', payload: '/SetSlots{"csat_score":"unsatisfied"}' },
+    ],
+  } as unknown as Message);
+
+/**
+ * Render the widget without letting it construct a real Rasa client.
+ * The constructor in componentWillLoad calls `new Rasa(...)` which would
+ * attempt to open a websocket; we pre-stub the client method on the prototype
+ * by wrapping componentWillLoad.
+ */
+const renderWidget = async (extraAttrs = 'enable-feedback="true"') => {
+  const originalComponentWillLoad = RasaChatbotWidget.prototype.componentWillLoad;
+  RasaChatbotWidget.prototype.componentWillLoad = function patched() {
+    const result = originalComponentWillLoad.call(this);
+    this.client = {
+      on: () => {},
+      connect: () => {},
+      disconnect: () => {},
+      reconnection: () => {},
+      sendMessage: () => {},
+      sendSilentMessage: () => {},
+      sessionId: 'test-session',
+      getChatHistory: () => '{}',
+      updateAuthenticationToken: () => {},
+      overrideChatHistory: () => {},
+    } as never;
+    return result;
+  };
+
+  try {
+    return await newSpecPage({
+      components: [RasaChatbotWidget],
+      html: `<rasa-chatbot-widget
+        server-url="http://localhost:5005"
+        ${extraAttrs}
+        feedback-question-text="How was it?"
+        feedback-thank-you-text="Thanks!"
+      ></rasa-chatbot-widget>`,
+    });
+  } finally {
+    RasaChatbotWidget.prototype.componentWillLoad = originalComponentWillLoad;
+  }
+};
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('RasaChatbotWidget loadHistory - refresh closes the popup', () => {
+  it('strips a QUICK_REPLY CSAT message from rendered history', async () => {
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    const history: Message[] = [divider(), text(), text(), csatButtons()];
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory(history);
+    await page.waitForChanges();
+
+    expect((widget as never as { messages: Message[] }).messages).toHaveLength(3);
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(false);
+  });
+
+  it('strips a CSAT-typed message from rendered history', async () => {
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    const history: Message[] = [divider(), text(), text(), csatTyped()];
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory(history);
+    await page.waitForChanges();
+
+    expect((widget as never as { messages: Message[] }).messages).toHaveLength(3);
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(false);
+  });
+
+  // Reported requirement: "if I refresh and I didn't rate, I don't want to
+  // see thumbs up and down". The pending CSAT expires with the session.
+  it('does NOT re-open the popup on refresh when the user did not rate', async () => {
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    const history: Message[] = [divider(), text(), text(), csatTyped()];
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory(history);
+    await page.waitForChanges();
+
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(false);
+  });
+
+  it('does NOT re-open the popup after multiple refreshes with trailing dividers', async () => {
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    const history: Message[] = [
+      divider(),
+      text(),
+      csatTyped(),
+      divider(),
+      divider(),
+      divider(),
+    ];
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory(history);
+    await page.waitForChanges();
+
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(false);
+  });
+
+  it('strips both CSAT shapes when they appear interleaved with text', async () => {
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    const history: Message[] = [
+      text(),
+      csatTyped('Round one?'),
+      text(),
+      csatButtons('Round two?'),
+      text(),
+    ];
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory(history);
+    await page.waitForChanges();
+
+    const remaining = (widget as never as { messages: Message[] }).messages;
+    expect(remaining).toHaveLength(3);
+    expect(remaining.every(m => m.type === MESSAGE_TYPES.TEXT)).toBe(true);
+  });
+
+  it('preserves non-CSAT QUICK_REPLY messages (yes/no flow, etc.)', async () => {
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    const nonCsatButtons = {
+      sender: SENDER.BOT,
+      type: MESSAGE_TYPES.QUICK_REPLY,
+      text: 'Continue?',
+      replies: [
+        { text: 'Yes', reply: '/affirm', isSelected: false },
+        { text: 'No', reply: '/deny', isSelected: false },
+      ],
+    } as unknown as Message;
+
+    const history: Message[] = [text(), nonCsatButtons];
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory(history);
+    await page.waitForChanges();
+
+    expect((widget as never as { messages: Message[] }).messages).toHaveLength(2);
+  });
+
+  it('passes through history untouched when feedback is disabled', async () => {
+    const page = await renderWidget('');
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    const history: Message[] = [divider(), text(), csatTyped(), divider()];
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory(history);
+    await page.waitForChanges();
+
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(false);
+    expect((widget as never as { messages: Message[] }).messages).toHaveLength(4);
+  });
+});
+
+describe('RasaChatbotWidget - cross-session CSAT lifecycle', () => {
+  // The hash-based answered memo is set when the user rates. It must be
+  // cleared on the next session-divider so a fresh CSAT in a new session
+  // (which reuses the same template and therefore the same content-hash)
+  // opens the popup again.
+  it('clears the answered hash when a new session begins', async () => {
+    const { isCsatAnsweredFor, markCsatAnswered } = await import('../utils/csat');
+
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+    const prompt = csatTyped('How was it?');
+
+    markCsatAnswered(prompt);
+    expect(isCsatAnsweredFor(prompt)).toBe(true);
+
+    (widget as never as { onNewMessage: (m: Message) => void }).onNewMessage(divider());
+    await page.waitForChanges();
+
+    expect(isCsatAnsweredFor(prompt)).toBe(false);
+  });
+
+  it('opens a fresh CSAT in a new conv after the user rated and refreshed', async () => {
+    const { markCsatAnswered } = await import('../utils/csat');
+
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+
+    // Pre-state: user already rated this template in a previous session.
+    markCsatAnswered(csatTyped('How was it?'));
+
+    // Refresh: history contains the rated prompt; the popup must stay closed.
+    (widget as never as { loadHistory: (d: Message[]) => void }).loadHistory([
+      divider(),
+      text(),
+      csatTyped('How was it?'),
+      divider(),
+    ]);
+    await page.waitForChanges();
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(false);
+
+    // Fresh session begins.
+    (widget as never as { onNewMessage: (m: Message) => void }).onNewMessage(divider());
+
+    // Bot eventually sends the same CSAT template in the new conversation.
+    (widget as never as { handleCsatRequest: (m: Message) => void }).handleCsatRequest(
+      csatTyped('How was it?'),
+    );
+    await page.waitForChanges();
+
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(true);
+  });
+
+  it('suppresses a server replay of an already-rated CSAT in the same session', async () => {
+    const { markCsatAnswered } = await import('../utils/csat');
+
+    const page = await renderWidget();
+    const widget = page.rootInstance as RasaChatbotWidget;
+    const prompt = csatTyped('How was it?');
+
+    markCsatAnswered(prompt);
+    (widget as never as { handleCsatRequest: (m: Message) => void }).handleCsatRequest(prompt);
+    await page.waitForChanges();
+
+    expect((widget as never as { showFeedback: boolean }).showFeedback).toBe(false);
+  });
+});

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.scss
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.scss
@@ -88,20 +88,35 @@
     flex-direction: column;
     gap: 24px;
     flex: 1 1 0%;
-    // Animate `padding-bottom` so the chat bubbles glide down into the
-    // space reclaimed when the feedback popup dismisses, instead of
-    // snapping. The widget removes the `--with-feedback` class the moment
-    // the thank-you starts its opacity fade, so this slide runs in
-    // lock-step with the popup fade and continues a bit past it for a
-    // soft landing. `easeOutCubic` decelerates very gently, removing the
-    // perceptible "stop" at the end.
-    transition: padding-bottom 0.9s cubic-bezier(0.22, 0.61, 0.36, 1);
-    will-change: padding-bottom;
   }
 
-  // Add bottom padding when feedback is enabled
+  // Reserve space below the last message so the absolutely-positioned
+  // feedback popup never overlaps a bubble. The popup itself sits at
+  // `bottom: 80px` from the messenger; the extra 24px on top of that
+  // mirrors the flex `gap` we previously got "for free" when the popup
+  // was a flex child of `.messenger__content`. Now that the host is
+  // `position: absolute` (so unmount doesn't cause a 24px layout jump),
+  // we have to add that clearance explicitly.
   &--with-feedback &__content {
-    padding-bottom: 80px;
+    padding-bottom: 104px;
+  }
+
+  // Animate `padding-bottom` only during the dismiss-down phase: the chat
+  // bubbles glide into the reclaimed space in lock-step with the popup's
+  // opacity fade. On the way *up* (popup appearing) we deliberately leave
+  // the transition off so the padding expands instantly - otherwise the
+  // popup would arrive at its final position while the messages were
+  // still sliding up, briefly overlapping a bubble. Linear timing avoids
+  // the "slow-tail snap" perception that ease-out curves produce on a
+  // 64+px slide.
+  //
+  // The 1.5s `transition-delay` matches `THANK_YOU_HOLD_MS` so the chat
+  // sits still during the hold and only starts sliding when the popup
+  // begins its fade-out. Driving this from CSS lets us drop the
+  // `setTimeout` the widget previously used to defer the class change.
+  &--feedback-dismissing &__content {
+    transition: padding-bottom 1s linear 1.5s;
+    will-change: padding-bottom;
   }
 
   &__content-wrapper {

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.scss
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.scss
@@ -88,6 +88,15 @@
     flex-direction: column;
     gap: 24px;
     flex: 1 1 0%;
+    // Animate `padding-bottom` so the chat bubbles glide down into the
+    // space reclaimed when the feedback popup dismisses, instead of
+    // snapping. The widget removes the `--with-feedback` class the moment
+    // the thank-you starts its opacity fade, so this slide runs in
+    // lock-step with the popup fade and continues a bit past it for a
+    // soft landing. `easeOutCubic` decelerates very gently, removing the
+    // perceptible "stop" at the end.
+    transition: padding-bottom 0.9s cubic-bezier(0.22, 0.61, 0.36, 1);
+    will-change: padding-bottom;
   }
 
   // Add bottom padding when feedback is enabled

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
@@ -27,9 +27,10 @@ import { DEBOUNCE_THRESHOLD, DISCONNECT_TIMEOUT } from './constants';
  * settle before tearing the popup out of the DOM. Removing it earlier lets
  * a DOM-removal repaint land in the middle of the chat slide, which reads
  * as a small "cut" at the end of the motion. The slide duration here
- * mirrors the CSS `transition: padding-bottom 0.9s` on `.messenger__content`.
+ * mirrors the CSS `transition: padding-bottom 1s linear` on
+ * `.messenger__content`.
  */
-const CONTENT_SLIDE_MS = 900;
+const CONTENT_SLIDE_MS = 1000;
 const FEEDBACK_UNMOUNT_DELAY_MS =
   CONVERSATION_FEEDBACK_TIMINGS.THANK_YOU_HOLD_MS + CONTENT_SLIDE_MS + 150;
 
@@ -579,17 +580,17 @@ export class RasaChatbotWidget {
       markCsatAnswered(this.currentCsatMessage);
     }
 
-    // Kick off the "dismissing" phase the moment the thank-you starts
-    // fading. This drops the `--with-feedback` class, letting the chat's
-    // bottom padding transition in lock-step with the popup's opacity
-    // fade. Without this sync the chat would only start sliding after
-    // the popup had fully unmounted, which reads as a hard cut.
-    setTimeout(() => {
-      this.isFeedbackDismissing = true;
-    }, CONVERSATION_FEEDBACK_TIMINGS.THANK_YOU_HOLD_MS);
+    // Flip into the "dismissing" phase immediately. The chat slide is gated
+    // on a CSS `transition-delay` (see `.messenger--feedback-dismissing
+    // .messenger__content` in rasa-chatbot-widget.scss) that waits out the
+    // 1.5s thank-you hold before actually sliding. No JS timer needed to
+    // schedule it - the CSS timeline handles the choreography.
+    this.isFeedbackDismissing = true;
 
-    // Unmount slightly after the child's fade-out completes so the CSS
-    // animation has time to play. See FEEDBACK_UNMOUNT_DELAY_MS.
+    // The only timer left in the feedback flow: unmount the popup once
+    // the CSS animations (thank-you fade + chat slide) have all settled.
+    // CSS can hide an element but can't remove it from the DOM, so this
+    // one setTimeout stays.
     setTimeout(() => {
       this.showFeedback = false;
       this.isFeedbackDismissing = false;
@@ -730,11 +731,12 @@ export class RasaChatbotWidget {
         <slot />
         <div class={widgetClassList}>
           <div class="rasa-chatbot-widget__container">
-            <Messenger 
-              isOpen={this.isOpen} 
-              toggleFullScreenMode={this.toggleFullscreenMode} 
+            <Messenger
+              isOpen={this.isOpen}
+              toggleFullScreenMode={this.toggleFullscreenMode}
               isFullScreen={this.isFullScreen}
               hasFeedback={this.showFeedback && this.isOpen && !this.isFeedbackDismissing}
+              isFeedbackDismissing={this.isFeedbackDismissing}
             >
               {this.messageHistory.map((message, key) => this.renderMessage(message, true, key))}
               {this.cachedMessages}

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, Event, EventEmitter, Listen, Prop, State, Watch, h } from '@stencil/core/internal';
 import { v4 as uuidv4 } from 'uuid';
 
-import { MESSAGE_TYPES, Message, QuickReply, QuickReplyMessage, Rasa, SENDER } from '@rasahq/chat-widget-sdk';
+import { MESSAGE_TYPES, Message, CsatMessage, QuickReply, QuickReplyMessage, Rasa, SENDER } from '@rasahq/chat-widget-sdk';
 
 import { Messenger } from '../components/messenger';
 import { configStore, setConfigStore } from '../store/config-store';
@@ -34,6 +34,18 @@ export class RasaChatbotWidget {
   @State() isConnected = false;
   @State() showFeedback = false;
   @State() feedbackSubmitted = false;
+  @State() csatQuestion = '';
+  @State() csatThankYou = '';
+
+  /**
+   * Default payloads sent to the channel when the user picks a rating. These
+   * fill the CALM `csat_score` slot via the response-button `/SetSlots` syntax.
+   * A CSAT request from the bot can override these per-message.
+   */
+  private csatPayloads: { satisfied: string; unsatisfied: string } = {
+    satisfied: '/SetSlots{"csat_score": "satisfied"}',
+    unsatisfied: '/SetSlots{"csat_score": "unsatisfied"}',
+  };
 
   /**
    * Emitted when the Chat Widget is opened by the user
@@ -288,6 +300,25 @@ export class RasaChatbotWidget {
 
     this.messageDelayQueue = this.messageDelayQueue.then(() => {
       return new Promise<void>(resolve => {
+        // CSAT request: the bot is asking for a satisfaction rating
+        // (e.g. via pattern_customer_satisfaction). Don't render it as a chat
+        // bubble - trigger the thumbs feedback component instead.
+        if (data.type === MESSAGE_TYPES.CSAT) {
+          this.typingIndicator = false;
+          this.handleCsatRequest(data as CsatMessage);
+          resolve();
+          return;
+        }
+
+        // CSAT request sent as a standard buttons message (the bot's
+        // `utter_ask_csat_score` with `csat_score` button payloads). Intercept
+        // it so it renders as the thumbs popup instead of in-chat buttons.
+        if (this.enableFeedback && data.type === MESSAGE_TYPES.QUICK_REPLY && this.handleCsatButtons(data as QuickReplyMessage)) {
+          this.typingIndicator = false;
+          resolve();
+          return;
+        }
+
         // Check if this is a "no_feedback" message - if so, skip delay and clear typing indicator immediately
         const isNoFeedback = 'text' in data && data.text && (data.text as string).trim() === 'no_feedback';
         
@@ -305,15 +336,6 @@ export class RasaChatbotWidget {
           messageQueueService.enqueueMessage(data);
           this.typingIndicator = false;
           
-          // Show feedback after bot message is processed
-          if (this.enableFeedback && !this.showFeedback && !this.feedbackSubmitted && 
-              'sender' in data && data.sender === SENDER.BOT) {
-            // Add a delay to ensure the message is fully rendered and added to this.messages
-            setTimeout(() => {
-              this.showConversationFeedback();
-            }, 800);
-          }
-          
           // If senderID is configured and message was sent from this tab, broadcast event to share chat history with other tabs with same senderID 
           if (this.senderId && this.sentMessage) {
             debounce(() => {
@@ -326,6 +348,75 @@ export class RasaChatbotWidget {
       });
     });
   };
+
+  /**
+   * Activates the thumbs feedback component in response to a bot-driven CSAT
+   * request. The question and thank-you text default to the widget props but
+   * can be overridden per-request by the bot. Option payloads (sent to the
+   * channel on submit) can likewise be overridden by the bot.
+   */
+  private handleCsatRequest(message: CsatMessage): void {
+    // `enableFeedback` is the integrator's master opt-in for the CSAT UI. When
+    // disabled, the request is ignored (and never rendered as a chat bubble).
+    if (!this.enableFeedback) {
+      return;
+    }
+
+    const satisfied = message.options?.find(option => option.value === 'satisfied');
+    const unsatisfied = message.options?.find(option => option.value === 'unsatisfied');
+    this.csatPayloads = {
+      satisfied: satisfied?.payload || this.csatPayloads.satisfied,
+      unsatisfied: unsatisfied?.payload || this.csatPayloads.unsatisfied,
+    };
+    this.csatQuestion = message.question || this.feedbackQuestionText;
+    this.csatThankYou = message.thankYou || this.feedbackThankYouText;
+    this.feedbackSubmitted = false;
+    this.showFeedback = true;
+  }
+
+  /**
+   * Detects a standard buttons message that is actually a CSAT request (its
+   * button payloads set the `csat_score` slot, e.g. from the bot's
+   * `utter_ask_csat_score`). When matched, the thumbs popup is shown using the
+   * bot's own button payloads, and the buttons are NOT rendered in the chat.
+   * Returns true when handled as CSAT, false otherwise.
+   */
+  private handleCsatButtons(message: QuickReplyMessage): boolean {
+    if (!message.replies?.length) {
+      return false;
+    }
+
+    let satisfiedPayload: string | undefined;
+    let unsatisfiedPayload: string | undefined;
+    for (const reply of message.replies) {
+      const payload = reply.reply || '';
+      const haystack = `${payload} ${reply.text || ''}`.toLowerCase();
+      // Order matters: check the negative case first so "not satisfied" /
+      // "unsatisfied" / "dissatisfied" don't get caught by the "satisfied" check.
+      if (/unsatisf|dissatisf|not[_\s-]?satisf|negative/.test(haystack)) {
+        unsatisfiedPayload = payload;
+      } else if (/satisf|positive/.test(haystack)) {
+        satisfiedPayload = payload;
+      }
+    }
+
+    // Not a CSAT buttons message - let it render as normal quick replies.
+    if (!satisfiedPayload && !unsatisfiedPayload) {
+      return false;
+    }
+
+    this.csatPayloads = {
+      satisfied: satisfiedPayload || this.csatPayloads.satisfied,
+      unsatisfied: unsatisfiedPayload || this.csatPayloads.unsatisfied,
+    };
+    // Prefer the integrator's configured question/thank-you text; fall back to
+    // the bot's button-message text.
+    this.csatQuestion = this.feedbackQuestionText || message.text || '';
+    this.csatThankYou = this.feedbackThankYouText;
+    this.feedbackSubmitted = false;
+    this.showFeedback = true;
+    return true;
+  }
 
   private loadHistory = (data: Message[]): void => {
     this.messages = data;
@@ -419,55 +510,15 @@ export class RasaChatbotWidget {
     setTimeout(() => {
       this.showFeedback = false;
     }, 3500); // 3.5 seconds to allow thank you message to show and fade
-    
-    // Pass the rating through unchanged - it already matches the Rasa CALM
-    // `csat_score` slot's categorical values.
-    const slotValue = event.detail.rating;
-    
-    // Set slot directly in Rasa tracker via REST API (with better error handling)
-    (async () => {
-      try {
-        // Simple check - if serverUrl is not available, skip slot setting
-        if (!this.serverUrl) {
-          return;
-        }
-        
-        // Extract base URL from server URL (remove /webhooks/rest/webhook if present)
-        let baseUrl = this.serverUrl;
-        if (baseUrl.includes('/webhooks/rest/webhook')) {
-          baseUrl = baseUrl.replace('/webhooks/rest/webhook', '');
-        }
-        
-        // Get current session ID
-        const sessionId = this.client?.sessionId || 'default';
-        
-        // Set slot via Rasa tracker events API
-        const response = await fetch(`${baseUrl}/conversations/${sessionId}/tracker/events`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            // Add authentication headers if needed
-            // 'Authorization': 'Bearer your-token',
-            // 'X-Auth-Token': 'your-token',
-            // 'API-Key': 'your-api-key'
-          },
-          body: JSON.stringify({
-            "event": "slot",
-            "name": "csat_score",
-            "value": slotValue,
-            "timestamp": null
-          })
-        });
-        
-        // Slot setting response handled silently
-        if (!response.ok) {
-          // Slot setting failed - error handled silently
-        }
-      } catch (error) {
-        // Slot setting error handled silently
-      }
-    })();
-    
+
+    // Send the rating to the bot through the normal channel so the active CSAT
+    // flow advances and the `csat_score` slot is filled. The payload is sent
+    // silently: it does not appear as a user message bubble in the chat.
+    const payload = this.csatPayloads[event.detail.rating];
+    if (payload) {
+      this.client.sendSilentMessage(payload);
+    }
+
     // Emit the event safely
     try {
       if (this.chatWidgetFeedbackSubmitted && this.chatWidgetFeedbackSubmitted.emit) {
@@ -476,27 +527,6 @@ export class RasaChatbotWidget {
     } catch (error) {
       // Silently handle event emission errors
     }
-  }
-
-
-  private showConversationFeedback(): void {
-    if (!this.enableFeedback || this.messages.length === 0 || !this.feedbackQuestionText.trim()) {
-      return;
-    }
-
-    const lastMessage = this.messages[this.messages.length - 1];
-    
-    // Don't show feedback if the last message is "no_feedback"
-    if (lastMessage && 'text' in lastMessage && lastMessage.text && (lastMessage.text as string).trim() === 'no_feedback') {
-      return;
-    }
-
-    // Don't show feedback if the last message is a quick_reply (in the middle of a flow)
-    if (lastMessage && lastMessage.type === MESSAGE_TYPES.QUICK_REPLY) {
-      return;
-    }
-
-    this.showFeedback = true;
   }
 
   private getAltText() {
@@ -637,17 +667,17 @@ export class RasaChatbotWidget {
               isOpen={this.isOpen} 
               toggleFullScreenMode={this.toggleFullscreenMode} 
               isFullScreen={this.isFullScreen}
-              hasFeedback={this.enableFeedback && this.isOpen}
+              hasFeedback={this.showFeedback && this.isOpen}
             >
               {this.messageHistory.map((message, key) => this.renderMessage(message, true, key))}
               {this.cachedMessages}
               {this.typingIndicator && <rasa-typing-indicator></rasa-typing-indicator>}
-              {this.enableFeedback && this.isOpen && (
+              {this.showFeedback && this.isOpen && (
                 <rasa-conversation-feedback 
                   show={this.showFeedback}
                   submitted={this.feedbackSubmitted}
-                  questionText={this.feedbackQuestionText}
-                  thankYouText={this.feedbackThankYouText}
+                  questionText={this.csatQuestion}
+                  thankYouText={this.csatThankYou}
                   onFeedbackSubmitted={this.handleFeedbackSubmitted}
                 ></rasa-conversation-feedback>
               )}

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
@@ -11,15 +11,27 @@ import { isValidURL } from '../utils/validate-url';
 import { broadcastChatHistoryEvent, receiveChatHistoryEvent } from '../utils/eventChannel';
 import { isMobile } from '../utils/isMobile';
 import { debounce } from '../utils/debounce';
+import {
+  detectCsatButtons,
+  isCsatAnsweredFor,
+  markCsatAnswered,
+  clearCsatAnswered,
+  CsatLikeMessage,
+} from '../utils/csat';
+import { CONVERSATION_FEEDBACK_TIMINGS } from '../components/conversation-feedback/conversation-feedback.timings';
 import { DEBOUNCE_THRESHOLD, DISCONNECT_TIMEOUT } from './constants';
 
 /**
- * sessionStorage flag tracking whether the most recent CSAT request has already
- * been answered. It shares the same lifetime as the chat history (sessionStorage),
- * so after a page refresh we can tell an answered CSAT request from a pending one
- * and avoid re-opening the thumbs popup for an already-rated conversation.
+ * Wait long enough for both the popup's opacity fade AND the chat's slide
+ * (which the SCSS triggers when `--with-feedback` is removed) to fully
+ * settle before tearing the popup out of the DOM. Removing it earlier lets
+ * a DOM-removal repaint land in the middle of the chat slide, which reads
+ * as a small "cut" at the end of the motion. The slide duration here
+ * mirrors the CSS `transition: padding-bottom 0.9s` on `.messenger__content`.
  */
-const CSAT_ANSWERED_STORAGE_KEY = 'rasa-csat-answered';
+const CONTENT_SLIDE_MS = 900;
+const FEEDBACK_UNMOUNT_DELAY_MS =
+  CONVERSATION_FEEDBACK_TIMINGS.THANK_YOU_HOLD_MS + CONTENT_SLIDE_MS + 150;
 
 @Component({
   tag: 'rasa-chatbot-widget',
@@ -32,6 +44,14 @@ export class RasaChatbotWidget {
   private disconnectTimeout: NodeJS.Timeout | null = null;
   private sentMessage = false;
 
+  /**
+   * The CSAT prompt currently driving the thumbs popup. Captured so the
+   * `feedbackSubmitted` handler can persist a per-prompt answered hash to
+   * sessionStorage, which makes the answered check survive a page refresh
+   * even when the server replays the same prompt on reconnect.
+   */
+  private currentCsatMessage: CsatLikeMessage | null = null;
+
   @Element() el: HTMLRasaChatbotWidgetElement;
   @State() isOpen: boolean = false;
   @State() isFullScreen: boolean = isMobile();
@@ -42,6 +62,13 @@ export class RasaChatbotWidget {
   @State() isConnected = false;
   @State() showFeedback = false;
   @State() feedbackSubmitted = false;
+  /**
+   * True from the moment the thank-you starts fading out until the popup
+   * fully unmounts. Used to collapse the chat content's bottom padding in
+   * sync with the popup's fade, so the chat bubbles glide down as the popup
+   * disappears - one continuous motion instead of fade-then-snap.
+   */
+  @State() isFeedbackDismissing = false;
   @State() csatQuestion = '';
   @State() csatThankYou = '';
 
@@ -295,15 +322,20 @@ export class RasaChatbotWidget {
     // If senderID is configured (continuous session), tab is not in focus and user message was not sent from this tab do not render new server message
     if (this.senderId && !document.hasFocus() && !this.sentMessage) return;
 
-    // Don't skip "no_feedback" messages - we need to add them to messages array to check for them
-    // They will be filtered out in renderMessage so they don't display
-
     this.chatWidgetReceivedMessage.emit(data);
     const delay = data.type === MESSAGE_TYPES.SESSION_DIVIDER || data.sender === SENDER.USER ? 0 : configStore().messageDelay;
     
     // Reset feedback state on new session
     if (data.type === MESSAGE_TYPES.SESSION_DIVIDER) {
       this.feedbackSubmitted = false;
+      // A new session means the per-prompt "answered" hash from the previous
+      // session is stale: the bot will likely reuse the same CSAT template
+      // (same question + same option payloads), which would otherwise
+      // hash-match the old answer and silently suppress the popup for the
+      // user's first CSAT in the fresh conversation. Replay-protection
+      // within a single session still works - it only kicks in for prompts
+      // marked answered AFTER this point.
+      clearCsatAnswered();
     }
 
     this.messageDelayQueue = this.messageDelayQueue.then(() => {
@@ -321,24 +353,26 @@ export class RasaChatbotWidget {
         // CSAT request sent as a standard buttons message (the bot's
         // `utter_ask_csat_score` with `csat_score` button payloads). Intercept
         // it so it renders as the thumbs popup instead of in-chat buttons.
-        if (this.enableFeedback && data.type === MESSAGE_TYPES.QUICK_REPLY && this.handleCsatButtons(data as QuickReplyMessage)) {
-          // Fresh ask from the bot: reset the answered flag so a refresh before
-          // the user rates will correctly re-open the popup.
-          this.setCsatAnswered(false);
-          this.typingIndicator = false;
-          resolve();
-          return;
-        }
-
-        // Check if this is a "no_feedback" message - if so, skip delay and clear typing indicator immediately
-        const isNoFeedback = 'text' in data && data.text && (data.text as string).trim() === 'no_feedback';
-        
-        if (isNoFeedback) {
-          // For "no_feedback" messages, don't show typing indicator and process immediately
-          this.typingIndicator = false;
-          messageQueueService.enqueueMessage(data);
-          resolve();
-          return;
+        if (this.enableFeedback && data.type === MESSAGE_TYPES.QUICK_REPLY) {
+          const csatMessage = data as QuickReplyMessage;
+          if (detectCsatButtons(csatMessage)) {
+            // Server replays of an already-answered prompt (e.g. on reconnect
+            // after a refresh) must NOT re-open the popup. We compare a
+            // content hash rather than relying on a global boolean so that
+            // a genuinely new CSAT request still shows the popup.
+            if (isCsatAnsweredFor(csatMessage)) {
+              this.typingIndicator = false;
+              resolve();
+              return;
+            }
+            // Genuinely fresh CSAT request: clear any stale answered hash so
+            // a refresh before the user rates correctly re-opens the popup.
+            clearCsatAnswered();
+            this.handleCsatButtons(csatMessage);
+            this.typingIndicator = false;
+            resolve();
+            return;
+          }
         }
 
         this.typingIndicator = delay > 0;
@@ -373,6 +407,13 @@ export class RasaChatbotWidget {
       return;
     }
 
+    // Replay of an already-rated CSAT (e.g. server re-pushed it after a
+    // reconnect): keep the popup closed.
+    if (isCsatAnsweredFor(message)) {
+      return;
+    }
+
+    clearCsatAnswered();
     const satisfied = message.options?.find(option => option.value === 'satisfied');
     const unsatisfied = message.options?.find(option => option.value === 'unsatisfied');
     this.csatPayloads = {
@@ -382,70 +423,28 @@ export class RasaChatbotWidget {
     this.csatQuestion = message.question || this.feedbackQuestionText;
     this.csatThankYou = message.thankYou || this.feedbackThankYouText;
     this.feedbackSubmitted = false;
-    this.setCsatAnswered(false);
+    this.currentCsatMessage = message;
     this.showFeedback = true;
-  }
-
-  /** Persisted "has the current CSAT request been answered?" flag. */
-  private isCsatAnswered(): boolean {
-    try {
-      return sessionStorage.getItem(CSAT_ANSWERED_STORAGE_KEY) === 'true';
-    } catch {
-      return false;
-    }
-  }
-
-  private setCsatAnswered(answered: boolean): void {
-    try {
-      sessionStorage.setItem(CSAT_ANSWERED_STORAGE_KEY, answered ? 'true' : 'false');
-    } catch {
-      // sessionStorage may be unavailable (e.g. private mode); the popup simply
-      // falls back to its in-memory behavior.
-    }
-  }
-
-  /**
-   * Inspects a buttons message and returns the CSAT option payloads when it is
-   * a satisfaction request (its buttons set the `csat_score` slot, e.g. from
-   * the bot's `utter_ask_csat_score`). Returns null when the message is a
-   * normal quick-reply message.
-   */
-  private detectCsatButtons(message: QuickReplyMessage): { satisfied?: string; unsatisfied?: string } | null {
-    if (!message.replies?.length) {
-      return null;
-    }
-
-    let satisfiedPayload: string | undefined;
-    let unsatisfiedPayload: string | undefined;
-    for (const reply of message.replies) {
-      const payload = reply.reply || '';
-      const haystack = `${payload} ${reply.text || ''}`.toLowerCase();
-      // Order matters: check the negative case first so "not satisfied" /
-      // "unsatisfied" / "dissatisfied" don't get caught by the "satisfied" check.
-      if (/unsatisf|dissatisf|not[_\s-]?satisf|negative/.test(haystack)) {
-        unsatisfiedPayload = payload;
-      } else if (/satisf|positive/.test(haystack)) {
-        satisfiedPayload = payload;
-      }
-    }
-
-    // Not a CSAT buttons message - let it render as normal quick replies.
-    if (!satisfiedPayload && !unsatisfiedPayload) {
-      return null;
-    }
-
-    return { satisfied: satisfiedPayload, unsatisfied: unsatisfiedPayload };
   }
 
   /**
    * Detects a standard buttons message that is actually a CSAT request and, if
    * so, shows the thumbs popup using the bot's own button payloads instead of
-   * rendering the buttons in the chat. Returns true when handled as CSAT.
+   * rendering the buttons in the chat. Returns true when handled as CSAT
+   * (even if the popup is suppressed because the same prompt was already
+   * answered earlier in this tab's session).
    */
   private handleCsatButtons(message: QuickReplyMessage): boolean {
-    const detected = this.detectCsatButtons(message);
+    const detected = detectCsatButtons(message);
     if (!detected) {
       return false;
+    }
+
+    // Already answered this exact prompt in this session: still classify as
+    // CSAT (so the caller strips the bubble from the chat), but do not
+    // re-open the popup.
+    if (isCsatAnsweredFor(message)) {
+      return true;
     }
 
     this.csatPayloads = {
@@ -457,43 +456,37 @@ export class RasaChatbotWidget {
     this.csatQuestion = this.feedbackQuestionText || message.text || '';
     this.csatThankYou = this.feedbackThankYouText;
     this.feedbackSubmitted = false;
+    this.currentCsatMessage = message;
     this.showFeedback = true;
     return true;
   }
 
   private loadHistory = (data: Message[]): void => {
-    // CSAT requests must be treated the same in history as in realtime: never
-    // render the bot's CSAT buttons message as a chat bubble. Strip them out,
-    // and if the last bot turn was an unanswered CSAT request, re-open the
-    // thumbs popup so the user can still rate after a page refresh.
     if (!this.enableFeedback) {
       this.messages = data;
       return;
     }
 
-    const lastIndex = data.length - 1;
-    let pendingCsat: QuickReplyMessage | null = null;
-    const filtered = data.filter((message, index) => {
-      if (message.type === MESSAGE_TYPES.QUICK_REPLY && this.detectCsatButtons(message as QuickReplyMessage)) {
-        // Only re-show the popup when the CSAT request is the very last message.
-        // An already-answered request is followed by further bot messages, so in
-        // that case we just drop the bubble without re-prompting.
-        if (index === lastIndex) {
-          pendingCsat = message as QuickReplyMessage;
-        }
+    // Strip CSAT prompts from the rendered history so the bot's raw
+    // "Was this helpful? [Yes] [No]" payload (whether sent as a typed CSAT
+    // response or as standard quick-reply buttons) never appears as a chat
+    // bubble after a page refresh.
+    //
+    // We intentionally do NOT re-open the thumbs popup from history: a
+    // CSAT request belongs to the live conversation in which it was sent,
+    // and once the page has been refreshed (rated or not) the prompt is
+    // considered expired. The popup will reappear when the bot sends a
+    // fresh CSAT in the new session.
+    this.messages = data.filter(message => {
+      if (message.type === MESSAGE_TYPES.CSAT) return false;
+      if (
+        message.type === MESSAGE_TYPES.QUICK_REPLY &&
+        !!detectCsatButtons(message as QuickReplyMessage)
+      ) {
         return false;
       }
       return true;
     });
-
-    this.messages = filtered;
-
-    // Re-open the popup only for a CSAT request that is both the last turn AND
-    // not yet answered. An answered request is sent silently (no follow-up
-    // bubble), so it would otherwise still look like the "last" message.
-    if (pendingCsat && !this.isCsatAnswered()) {
-      this.handleCsatButtons(pendingCsat);
-    }
   };
 
   private connect(): void {
@@ -579,14 +572,29 @@ export class RasaChatbotWidget {
   private handleFeedbackSubmitted(event: CustomEvent<{ rating: 'satisfied' | 'unsatisfied'; helpful: boolean }>) {
     // Set feedbackSubmitted to prevent showing feedback again in this conversation
     this.feedbackSubmitted = true;
-    // Persist the answered state so a page refresh does not re-open the popup
-    // for a CSAT request the user has already rated.
-    this.setCsatAnswered(true);
-    
-    // Allow time for thank you message to show, then hide the component
+    // Persist a per-prompt answered hash so a refresh - even a refresh that
+    // races the bot's silent ack - does not re-open the popup for the prompt
+    // the user just rated. Done synchronously, before any async work.
+    if (this.currentCsatMessage) {
+      markCsatAnswered(this.currentCsatMessage);
+    }
+
+    // Kick off the "dismissing" phase the moment the thank-you starts
+    // fading. This drops the `--with-feedback` class, letting the chat's
+    // bottom padding transition in lock-step with the popup's opacity
+    // fade. Without this sync the chat would only start sliding after
+    // the popup had fully unmounted, which reads as a hard cut.
+    setTimeout(() => {
+      this.isFeedbackDismissing = true;
+    }, CONVERSATION_FEEDBACK_TIMINGS.THANK_YOU_HOLD_MS);
+
+    // Unmount slightly after the child's fade-out completes so the CSS
+    // animation has time to play. See FEEDBACK_UNMOUNT_DELAY_MS.
     setTimeout(() => {
       this.showFeedback = false;
-    }, 3500); // 3.5 seconds to allow thank you message to show and fade
+      this.isFeedbackDismissing = false;
+      this.currentCsatMessage = null;
+    }, FEEDBACK_UNMOUNT_DELAY_MS);
 
     // Send the rating to the bot through the normal channel so the active CSAT
     // flow advances and the `csat_score` slot is filled. The payload is sent
@@ -635,29 +643,11 @@ export class RasaChatbotWidget {
   @Watch('messages')
   onMessagesChange() {
     if (this.cachedMessages.length !== this.messages.length) {
-      const previousLength = this.cachedMessages.length;
-      const renderedMessages = this.messages.map((message, key) => {
-        const rendered = this.renderMessage(message, false, key);
-        // If message was filtered out (no_feedback) and it's the newly added message, complete rendering to unblock the queue
-        if (rendered === null && 'text' in message && message.text && (message.text as string).trim() === 'no_feedback' && key >= previousLength) {
-          // Complete rendering for filtered messages to prevent queue from getting stuck
-          setTimeout(() => {
-            messageQueueService.completeRendering();
-          }, 0);
-        }
-        return rendered;
-      });
-      this.cachedMessages = renderedMessages;
+      this.cachedMessages = this.messages.map((message, key) => this.renderMessage(message, false, key));
     }
   }
 
   private renderMessage(message: Message, isHistory = false, key) {
-    // Always filter out "no_feedback" messages - these are control messages from Rasa
-    // This filtering is independent of feedback settings (enableFeedback prop)
-    if ('text' in message && message.text && (message.text as string).trim() === 'no_feedback') {
-      return null;
-    }
-
     switch (message.type) {
       case MESSAGE_TYPES.SESSION_DIVIDER:
         return <rasa-session-divider sessionStartDate={message.startDate} sessionStartedText={this.sessionStartedText} key={key}></rasa-session-divider>;
@@ -744,7 +734,7 @@ export class RasaChatbotWidget {
               isOpen={this.isOpen} 
               toggleFullScreenMode={this.toggleFullscreenMode} 
               isFullScreen={this.isFullScreen}
-              hasFeedback={this.showFeedback && this.isOpen}
+              hasFeedback={this.showFeedback && this.isOpen && !this.isFeedbackDismissing}
             >
               {this.messageHistory.map((message, key) => this.renderMessage(message, true, key))}
               {this.cachedMessages}

--- a/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
+++ b/packages/ui/src/rasa-chatbot-widget/rasa-chatbot-widget.tsx
@@ -13,6 +13,14 @@ import { isMobile } from '../utils/isMobile';
 import { debounce } from '../utils/debounce';
 import { DEBOUNCE_THRESHOLD, DISCONNECT_TIMEOUT } from './constants';
 
+/**
+ * sessionStorage flag tracking whether the most recent CSAT request has already
+ * been answered. It shares the same lifetime as the chat history (sessionStorage),
+ * so after a page refresh we can tell an answered CSAT request from a pending one
+ * and avoid re-opening the thumbs popup for an already-rated conversation.
+ */
+const CSAT_ANSWERED_STORAGE_KEY = 'rasa-csat-answered';
+
 @Component({
   tag: 'rasa-chatbot-widget',
   styleUrl: 'rasa-chatbot-widget.scss',
@@ -314,6 +322,9 @@ export class RasaChatbotWidget {
         // `utter_ask_csat_score` with `csat_score` button payloads). Intercept
         // it so it renders as the thumbs popup instead of in-chat buttons.
         if (this.enableFeedback && data.type === MESSAGE_TYPES.QUICK_REPLY && this.handleCsatButtons(data as QuickReplyMessage)) {
+          // Fresh ask from the bot: reset the answered flag so a refresh before
+          // the user rates will correctly re-open the popup.
+          this.setCsatAnswered(false);
           this.typingIndicator = false;
           resolve();
           return;
@@ -371,19 +382,37 @@ export class RasaChatbotWidget {
     this.csatQuestion = message.question || this.feedbackQuestionText;
     this.csatThankYou = message.thankYou || this.feedbackThankYouText;
     this.feedbackSubmitted = false;
+    this.setCsatAnswered(false);
     this.showFeedback = true;
   }
 
-  /**
-   * Detects a standard buttons message that is actually a CSAT request (its
-   * button payloads set the `csat_score` slot, e.g. from the bot's
-   * `utter_ask_csat_score`). When matched, the thumbs popup is shown using the
-   * bot's own button payloads, and the buttons are NOT rendered in the chat.
-   * Returns true when handled as CSAT, false otherwise.
-   */
-  private handleCsatButtons(message: QuickReplyMessage): boolean {
-    if (!message.replies?.length) {
+  /** Persisted "has the current CSAT request been answered?" flag. */
+  private isCsatAnswered(): boolean {
+    try {
+      return sessionStorage.getItem(CSAT_ANSWERED_STORAGE_KEY) === 'true';
+    } catch {
       return false;
+    }
+  }
+
+  private setCsatAnswered(answered: boolean): void {
+    try {
+      sessionStorage.setItem(CSAT_ANSWERED_STORAGE_KEY, answered ? 'true' : 'false');
+    } catch {
+      // sessionStorage may be unavailable (e.g. private mode); the popup simply
+      // falls back to its in-memory behavior.
+    }
+  }
+
+  /**
+   * Inspects a buttons message and returns the CSAT option payloads when it is
+   * a satisfaction request (its buttons set the `csat_score` slot, e.g. from
+   * the bot's `utter_ask_csat_score`). Returns null when the message is a
+   * normal quick-reply message.
+   */
+  private detectCsatButtons(message: QuickReplyMessage): { satisfied?: string; unsatisfied?: string } | null {
+    if (!message.replies?.length) {
+      return null;
     }
 
     let satisfiedPayload: string | undefined;
@@ -402,12 +431,26 @@ export class RasaChatbotWidget {
 
     // Not a CSAT buttons message - let it render as normal quick replies.
     if (!satisfiedPayload && !unsatisfiedPayload) {
+      return null;
+    }
+
+    return { satisfied: satisfiedPayload, unsatisfied: unsatisfiedPayload };
+  }
+
+  /**
+   * Detects a standard buttons message that is actually a CSAT request and, if
+   * so, shows the thumbs popup using the bot's own button payloads instead of
+   * rendering the buttons in the chat. Returns true when handled as CSAT.
+   */
+  private handleCsatButtons(message: QuickReplyMessage): boolean {
+    const detected = this.detectCsatButtons(message);
+    if (!detected) {
       return false;
     }
 
     this.csatPayloads = {
-      satisfied: satisfiedPayload || this.csatPayloads.satisfied,
-      unsatisfied: unsatisfiedPayload || this.csatPayloads.unsatisfied,
+      satisfied: detected.satisfied || this.csatPayloads.satisfied,
+      unsatisfied: detected.unsatisfied || this.csatPayloads.unsatisfied,
     };
     // Prefer the integrator's configured question/thank-you text; fall back to
     // the bot's button-message text.
@@ -419,7 +462,38 @@ export class RasaChatbotWidget {
   }
 
   private loadHistory = (data: Message[]): void => {
-    this.messages = data;
+    // CSAT requests must be treated the same in history as in realtime: never
+    // render the bot's CSAT buttons message as a chat bubble. Strip them out,
+    // and if the last bot turn was an unanswered CSAT request, re-open the
+    // thumbs popup so the user can still rate after a page refresh.
+    if (!this.enableFeedback) {
+      this.messages = data;
+      return;
+    }
+
+    const lastIndex = data.length - 1;
+    let pendingCsat: QuickReplyMessage | null = null;
+    const filtered = data.filter((message, index) => {
+      if (message.type === MESSAGE_TYPES.QUICK_REPLY && this.detectCsatButtons(message as QuickReplyMessage)) {
+        // Only re-show the popup when the CSAT request is the very last message.
+        // An already-answered request is followed by further bot messages, so in
+        // that case we just drop the bubble without re-prompting.
+        if (index === lastIndex) {
+          pendingCsat = message as QuickReplyMessage;
+        }
+        return false;
+      }
+      return true;
+    });
+
+    this.messages = filtered;
+
+    // Re-open the popup only for a CSAT request that is both the last turn AND
+    // not yet answered. An answered request is sent silently (no follow-up
+    // bubble), so it would otherwise still look like the "last" message.
+    if (pendingCsat && !this.isCsatAnswered()) {
+      this.handleCsatButtons(pendingCsat);
+    }
   };
 
   private connect(): void {
@@ -505,6 +579,9 @@ export class RasaChatbotWidget {
   private handleFeedbackSubmitted(event: CustomEvent<{ rating: 'satisfied' | 'unsatisfied'; helpful: boolean }>) {
     // Set feedbackSubmitted to prevent showing feedback again in this conversation
     this.feedbackSubmitted = true;
+    // Persist the answered state so a page refresh does not re-open the popup
+    // for a CSAT request the user has already rated.
+    this.setCsatAnswered(true);
     
     // Allow time for thank you message to show, then hide the component
     setTimeout(() => {

--- a/packages/ui/src/utils/csat.test.ts
+++ b/packages/ui/src/utils/csat.test.ts
@@ -22,8 +22,7 @@ const makeQuickReply = (
   sender: SENDER.BOT,
   type: MESSAGE_TYPES.QUICK_REPLY,
   text,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  replies: replies.map(r => ({ ...r, isSelected: false })) as any,
+  replies: replies.map(r => ({ ...r, isSelected: false })) as unknown as QuickReplyMessage['replies'],
 });
 
 const makeCsat = (

--- a/packages/ui/src/utils/csat.test.ts
+++ b/packages/ui/src/utils/csat.test.ts
@@ -1,0 +1,299 @@
+import {
+  CSAT_ANSWERED_HASH_STORAGE_KEY,
+  clearCsatAnswered,
+  detectCsatButtons,
+  findLastContentIndex,
+  getCsatMessageHash,
+  isCsatAnsweredFor,
+  markCsatAnswered,
+} from './csat';
+import {
+  MESSAGE_TYPES,
+  Message,
+  QuickReplyMessage,
+  CsatMessage,
+  SENDER,
+} from '@rasahq/chat-widget-sdk';
+
+const makeQuickReply = (
+  replies: Array<{ text: string; reply: string }>,
+  text = 'Was this helpful?'
+): QuickReplyMessage => ({
+  sender: SENDER.BOT,
+  type: MESSAGE_TYPES.QUICK_REPLY,
+  text,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  replies: replies.map(r => ({ ...r, isSelected: false })) as any,
+});
+
+const makeCsat = (
+  question: string,
+  options: Array<{ value: string; payload: string }> = [],
+  thankYou?: string
+): CsatMessage => ({
+  sender: SENDER.BOT,
+  type: MESSAGE_TYPES.CSAT,
+  question,
+  thankYou,
+  options,
+});
+
+describe('detectCsatButtons', () => {
+  it('returns null when message has no replies', () => {
+    const message = makeQuickReply([]);
+    expect(detectCsatButtons(message)).toBeNull();
+  });
+
+  it('returns null when no reply matches the CSAT vocabulary', () => {
+    const message = makeQuickReply([
+      { text: 'Yes', reply: '/affirm' },
+      { text: 'No', reply: '/deny' },
+    ]);
+    expect(detectCsatButtons(message)).toBeNull();
+  });
+
+  it('detects payloads that explicitly set satisfied / unsatisfied', () => {
+    const message = makeQuickReply([
+      { text: 'Yes', reply: '/SetSlots{"csat_score":"satisfied"}' },
+      { text: 'No', reply: '/SetSlots{"csat_score":"unsatisfied"}' },
+    ]);
+    expect(detectCsatButtons(message)).toEqual({
+      satisfied: '/SetSlots{"csat_score":"satisfied"}',
+      unsatisfied: '/SetSlots{"csat_score":"unsatisfied"}',
+    });
+  });
+
+  it('detects via positive/negative vocabulary on the button text', () => {
+    const message = makeQuickReply([
+      { text: 'positive feedback', reply: '/pos' },
+      { text: 'negative feedback', reply: '/neg' },
+    ]);
+    expect(detectCsatButtons(message)).toEqual({
+      satisfied: '/pos',
+      unsatisfied: '/neg',
+    });
+  });
+
+  it('checks the negative case first so "not_satisfied" does not match "satisfied"', () => {
+    const message = makeQuickReply([
+      { text: 'Yes', reply: '/satisfied' },
+      { text: 'No', reply: '/not_satisfied' },
+    ]);
+    const result = detectCsatButtons(message);
+    expect(result?.satisfied).toBe('/satisfied');
+    expect(result?.unsatisfied).toBe('/not_satisfied');
+  });
+
+  it('returns a partial result when only one polarity is recognised', () => {
+    const message = makeQuickReply([
+      { text: 'Satisfied', reply: '/satisfied' },
+      { text: 'Cancel', reply: '/cancel' },
+    ]);
+    expect(detectCsatButtons(message)).toEqual({
+      satisfied: '/satisfied',
+      unsatisfied: undefined,
+    });
+  });
+});
+
+describe('getCsatMessageHash', () => {
+  it('produces identical hashes for two CSAT prompts with the same content', () => {
+    const a = makeCsat('How was your experience?', [
+      { value: 'satisfied', payload: '/SetSlots{"csat_score":"satisfied"}' },
+      { value: 'unsatisfied', payload: '/SetSlots{"csat_score":"unsatisfied"}' },
+    ]);
+    const b = makeCsat('How was your experience?', [
+      { value: 'satisfied', payload: '/SetSlots{"csat_score":"satisfied"}' },
+      { value: 'unsatisfied', payload: '/SetSlots{"csat_score":"unsatisfied"}' },
+    ]);
+    // Different timestamps / sender object identities must not affect the hash.
+    expect(getCsatMessageHash(a)).toBe(getCsatMessageHash(b));
+  });
+
+  it('produces different hashes when the question differs', () => {
+    const a = makeCsat('Question one?', []);
+    const b = makeCsat('Question two?', []);
+    expect(getCsatMessageHash(a)).not.toBe(getCsatMessageHash(b));
+  });
+
+  it('produces different hashes when the option payloads differ', () => {
+    const a = makeCsat('Q?', [{ value: 'satisfied', payload: '/v1' }]);
+    const b = makeCsat('Q?', [{ value: 'satisfied', payload: '/v2' }]);
+    expect(getCsatMessageHash(a)).not.toBe(getCsatMessageHash(b));
+  });
+
+  it('hashes QuickReplyMessage and CsatMessage representations consistently', () => {
+    const cs = makeCsat('Was this helpful?', [
+      { value: 'satisfied', payload: '/pos' },
+      { value: 'unsatisfied', payload: '/neg' },
+    ]);
+    const qr = makeQuickReply(
+      [
+        { text: 'Satisfied', reply: '/pos' },
+        { text: 'Unsatisfied', reply: '/neg' },
+      ],
+      'Was this helpful?'
+    );
+    // Different message shapes are not expected to collide; we just verify
+    // hashes are deterministic and JSON-serialisable.
+    expect(typeof getCsatMessageHash(cs)).toBe('string');
+    expect(typeof getCsatMessageHash(qr)).toBe('string');
+    expect(getCsatMessageHash(qr)).toBe(getCsatMessageHash(qr));
+  });
+});
+
+describe('CSAT answered persistence', () => {
+  let store: Record<string, string>;
+  let storage: {
+    getItem: jest.Mock;
+    setItem: jest.Mock;
+    removeItem: jest.Mock;
+  };
+
+  beforeEach(() => {
+    store = {};
+    storage = {
+      getItem: jest.fn((key: string) => (key in store ? store[key] : null)),
+      setItem: jest.fn((key: string, value: string) => {
+        store[key] = value;
+      }),
+      removeItem: jest.fn((key: string) => {
+        delete store[key];
+      }),
+    };
+  });
+
+  const csat = makeCsat('Rate me?', [
+    { value: 'satisfied', payload: '/pos' },
+    { value: 'unsatisfied', payload: '/neg' },
+  ]);
+
+  it('is not answered when nothing has been persisted', () => {
+    expect(isCsatAnsweredFor(csat, storage)).toBe(false);
+  });
+
+  it('reports answered for the exact same prompt that was marked', () => {
+    markCsatAnswered(csat, storage);
+    expect(isCsatAnsweredFor(csat, storage)).toBe(true);
+    expect(store[CSAT_ANSWERED_HASH_STORAGE_KEY]).toBeDefined();
+  });
+
+  it('reports not answered for a different prompt even if storage has a value', () => {
+    markCsatAnswered(csat, storage);
+    const otherPrompt = makeCsat('A different question?', []);
+    expect(isCsatAnsweredFor(otherPrompt, storage)).toBe(false);
+  });
+
+  it('clearCsatAnswered removes the persisted hash', () => {
+    markCsatAnswered(csat, storage);
+    clearCsatAnswered(storage);
+    expect(isCsatAnsweredFor(csat, storage)).toBe(false);
+    expect(storage.removeItem).toHaveBeenCalledWith(CSAT_ANSWERED_HASH_STORAGE_KEY);
+  });
+
+  it('gracefully handles a null storage (e.g. Safari private mode)', () => {
+    expect(() => markCsatAnswered(csat, null)).not.toThrow();
+    expect(() => clearCsatAnswered(null)).not.toThrow();
+    expect(isCsatAnsweredFor(csat, null)).toBe(false);
+  });
+
+  it('does not throw when storage operations fail', () => {
+    const failing: typeof storage = {
+      getItem: jest.fn(() => {
+        throw new Error('boom');
+      }),
+      setItem: jest.fn(() => {
+        throw new Error('boom');
+      }),
+      removeItem: jest.fn(() => {
+        throw new Error('boom');
+      }),
+    };
+
+    expect(isCsatAnsweredFor(csat, failing)).toBe(false);
+    expect(() => markCsatAnswered(csat, failing)).not.toThrow();
+    expect(() => clearCsatAnswered(failing)).not.toThrow();
+  });
+
+  describe('refresh / replay scenario', () => {
+    // Regression coverage for the PR feedback:
+    // "After first refresh, if thumbsup was present, it remains.
+    //  After second refresh it goes away. It should go away instantly."
+    //
+    // Before the fix the answered state was a plain boolean and a server
+    // replay of the same CSAT (very common right after reconnect) would
+    // overwrite/reset it. Now we hash the prompt itself, so a replay is
+    // recognised as already-answered.
+
+    it('treats a server replay of the rated prompt as already-answered', () => {
+      const original = makeCsat('Rate me?', [
+        { value: 'satisfied', payload: '/pos' },
+        { value: 'unsatisfied', payload: '/neg' },
+      ]);
+      markCsatAnswered(original, storage);
+
+      // Same prompt arrives again on reconnect with a fresh timestamp.
+      const replay: CsatMessage = { ...original };
+      expect(isCsatAnsweredFor(replay, storage)).toBe(true);
+    });
+
+    it('does not suppress a genuinely new CSAT prompt that happens to come later', () => {
+      const first = makeCsat('Rate experience A?', []);
+      markCsatAnswered(first, storage);
+
+      const second = makeCsat('Rate experience B?', []);
+      expect(isCsatAnsweredFor(second, storage)).toBe(false);
+    });
+  });
+});
+
+describe('findLastContentIndex', () => {
+  // Regression coverage: every page refresh without a stable sender-id
+  // creates a new session entry, which `parseChatHistory` then surfaces as
+  // a trailing SESSION_DIVIDER. Before this helper, a naive "last index"
+  // check would lose the CSAT prompt after the second refresh and the
+  // popup would never re-open. Dividers must be transparent.
+
+  const divider = (): Message =>
+    ({ type: MESSAGE_TYPES.SESSION_DIVIDER, startDate: new Date() } as Message);
+
+  const text = (sender: (typeof SENDER)[keyof typeof SENDER] = SENDER.BOT): Message =>
+    ({ sender, type: MESSAGE_TYPES.TEXT, text: 'hi' } as Message);
+
+  const csat = (): Message =>
+    makeQuickReply(
+      [
+        { text: 'Yes', reply: '/satisfied' },
+        { text: 'No', reply: '/unsatisfied' },
+      ],
+      'Was this helpful?'
+    ) as Message;
+
+  it('returns -1 for an empty history', () => {
+    expect(findLastContentIndex([])).toBe(-1);
+  });
+
+  it('returns -1 when the history only contains dividers', () => {
+    expect(findLastContentIndex([divider(), divider()])).toBe(-1);
+  });
+
+  it('returns the index of a CSAT message that is genuinely last', () => {
+    const history = [text(), text(), csat()];
+    expect(findLastContentIndex(history)).toBe(2);
+  });
+
+  it('skips a single trailing divider (first refresh)', () => {
+    const history = [text(), text(), csat(), divider()];
+    expect(findLastContentIndex(history)).toBe(2);
+  });
+
+  it('skips multiple trailing dividers (Nth refresh without sender-id)', () => {
+    const history = [text(), text(), csat(), divider(), divider(), divider()];
+    expect(findLastContentIndex(history)).toBe(2);
+  });
+
+  it('returns the user/bot turn after a CSAT once one exists', () => {
+    const history = [text(), csat(), text(SENDER.USER), divider()];
+    expect(findLastContentIndex(history)).toBe(2);
+  });
+});

--- a/packages/ui/src/utils/csat.ts
+++ b/packages/ui/src/utils/csat.ts
@@ -1,0 +1,132 @@
+import { CsatMessage, MESSAGE_TYPES, Message, QuickReplyMessage } from '@rasahq/chat-widget-sdk';
+
+/**
+ * sessionStorage key used to remember which CSAT prompt the user has already
+ * answered. The value is a stable content hash of the prompt - not just a
+ * boolean - so that a server-side replay of the same message after a refresh
+ * is correctly recognised as already-answered, instead of being treated as a
+ * fresh ask that re-opens the thumbs popup.
+ */
+export const CSAT_ANSWERED_HASH_STORAGE_KEY = 'rasa-csat-answered-hash';
+
+export type CsatLikeMessage = CsatMessage | QuickReplyMessage;
+
+export interface CsatPayloads {
+  satisfied?: string;
+  unsatisfied?: string;
+}
+
+/**
+ * Inspects a buttons message and returns the CSAT option payloads when it is
+ * a satisfaction request. Returns null when the message is a normal
+ * quick-reply (i.e. its button text/payloads do not match the `satisfied` /
+ * `unsatisfied` vocabulary).
+ *
+ * Pure function so we can unit-test the heuristic in isolation.
+ */
+export function detectCsatButtons(message: QuickReplyMessage): CsatPayloads | null {
+  if (!message?.replies?.length) {
+    return null;
+  }
+
+  let satisfiedPayload: string | undefined;
+  let unsatisfiedPayload: string | undefined;
+  for (const reply of message.replies) {
+    const payload = reply.reply || '';
+    const haystack = `${payload} ${reply.text || ''}`.toLowerCase();
+    // Order matters: check the negative case first so "not satisfied" /
+    // "unsatisfied" / "dissatisfied" don't get caught by the "satisfied" check.
+    if (/unsatisf|dissatisf|not[_\s-]?satisf|negative/.test(haystack)) {
+      unsatisfiedPayload = payload;
+    } else if (/satisf|positive/.test(haystack)) {
+      satisfiedPayload = payload;
+    }
+  }
+
+  if (!satisfiedPayload && !unsatisfiedPayload) {
+    return null;
+  }
+
+  return { satisfied: satisfiedPayload, unsatisfied: unsatisfiedPayload };
+}
+
+/**
+ * Produces a stable content hash for a CSAT prompt that is robust to the
+ * non-stable fields that vary between a fresh push and a server replay
+ * (timestamps, sender, etc.). Two CSAT prompts with the same question and
+ * the same option vocabulary will hash identically.
+ */
+export function getCsatMessageHash(message: CsatLikeMessage): string {
+  const anyMessage = message as Partial<CsatMessage> & Partial<QuickReplyMessage>;
+  const question = anyMessage.question || anyMessage.text || '';
+  const options = anyMessage.options?.map(o => ({ value: o.value, payload: o.payload }));
+  const replies = anyMessage.replies?.map(r => ({ text: r.text, reply: r.reply }));
+  return JSON.stringify({ question, options, replies });
+}
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function getStorage(): StorageLike | null {
+  try {
+    if (typeof sessionStorage === 'undefined') return null;
+    return sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true iff the provided CSAT prompt has already been answered in the
+ * current browser tab (sessionStorage). The hash comparison means a server
+ * replay of the same prompt after a page refresh is treated as
+ * "already answered", which fixes the bug where the popup briefly re-appeared
+ * after rating + refresh.
+ */
+export function isCsatAnsweredFor(message: CsatLikeMessage, storage: StorageLike | null = getStorage()): boolean {
+  if (!storage) return false;
+  try {
+    const storedHash = storage.getItem(CSAT_ANSWERED_HASH_STORAGE_KEY);
+    if (!storedHash) return false;
+    return storedHash === getCsatMessageHash(message);
+  } catch {
+    return false;
+  }
+}
+
+export function markCsatAnswered(message: CsatLikeMessage, storage: StorageLike | null = getStorage()): void {
+  if (!storage) return;
+  try {
+    storage.setItem(CSAT_ANSWERED_HASH_STORAGE_KEY, getCsatMessageHash(message));
+  } catch {
+    // sessionStorage may be unavailable (e.g. Safari private mode).
+  }
+}
+
+export function clearCsatAnswered(storage: StorageLike | null = getStorage()): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(CSAT_ANSWERED_HASH_STORAGE_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+/**
+ * Returns the index of the last non-divider message, or -1 when the history
+ * only contains dividers (or is empty). Session dividers are transparent for
+ * "is the popup still pending?" purposes because every page refresh appends
+ * a new (often empty) session entry, which would otherwise push real bot
+ * turns out of the "last message" slot from the second refresh onwards.
+ */
+export function findLastContentIndex(history: Message[]): number {
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].type !== MESSAGE_TYPES.SESSION_DIVIDER) {
+      return i;
+    }
+  }
+  return -1;
+}


### PR DESCRIPTION
## Summary

Adds a built-in CSAT (Customer Satisfaction) score collection flow to the chat widget. When the bot triggers a CSAT request, the widget now shows a thumbs-up / thumbs-down popup instead of a chat bubble, and the user's selection is sent back to the bot to fill the CALM `csat_score` slot.

## Changes

### SDK (`@rasahq/chat-widget-sdk`)

- New `csat` message type with corresponding `CsatResponse` / `HttpCsatResponse` server types and `CsatMessage` parsed-message type. CSAT payloads can include an optional `question`, `thank_you` text, and `options[]` (each with `value` and `payload`).
- New parser (`MessageParsers.csat`) and detector (`messageTypeMap.csat`) that recognise `type: "csat"` custom payloads.
- New public API `Rasa.sendSilentMessage(payload)`: forwards a payload through the channel without echoing it as a user bubble or persisting it to history. Used by the UI to send the user's rating after they pick a thumb.
- `hasCustomAttribute` extended to include `csat`, so HTTP REST responses with `custom.type = "csat"` are recognised.

### UI widget (`@rasahq/chat-widget-ui`)

- The widget intercepts two flavours of CSAT requests from the bot before they hit the chat history:
  1. **First-class `csat` custom-payload messages** (`MESSAGE_TYPES.CSAT`) — handled by `handleCsatRequest`.
  2. **Standard buttons messages** (e.g. `utter_ask_csat_score`) whose button payloads target the `csat_score` slot — handled by `handleCsatButtons`. Detection is heuristic on payload + button text and matches `satisfied` / `unsatisfied` / `dissatisfied` / `not_satisfied` / `positive` / `negative` (negative case checked first to avoid false positives).
- Both paths swap the chat-bubble rendering for the existing thumbs feedback popup.
- Bot can override the question text, thank-you text, and the per-option payloads per request; otherwise the integrator's `feedbackQuestionText` / `feedbackThankYouText` props and sensible defaults (`/SetSlots{\"csat_score\": \"satisfied\"}` / `\"unsatisfied\"`) are used.
- On submission, the rating is sent via the new `sendSilentMessage` SDK API. This replaces the previous direct `fetch` to Rasa's `/conversations/{id}/tracker/events` endpoint, which required CORS and exposing the tracker API publicly.
- Removed the legacy behaviour that auto-showed the feedback popup after every bot text message. Feedback is now only triggered when the bot explicitly asks for CSAT.
- Header `hasFeedback` and the `<rasa-conversation-feedback>` element now follow `showFeedback` state rather than the static `enableFeedback` prop.

### Examples

- `examples/html/index.html` and `examples/react/feedback-example.tsx` cleaned up: replaced hard-coded Cyrillic strings and `aiasistent.gov.rs` server URL with English defaults / `localhost:5005` so the examples are useful as generic starting points.

## Post-merge steps
1. Merge this PR into `main`
2. Run the **Chat Widget Publish** workflow with `version: patch` to publish **v0.1.17**

## Test plan
- [ ] CI passes (lint + build)
- [ ] Bot sends a `csat` custom payload → widget shows the thumbs popup with the bot's question/thank-you and submitting calls `sendSilentMessage` with the matching option payload
- [ ] Bot sends `utter_ask_csat_score` as a buttons message → widget detects it, hides the buttons, shows the thumbs popup, and submission fills the `csat_score` slot
- [ ] A regular bot text message no longer auto-shows the feedback popup
- [ ] Non-CSAT buttons messages still render as quick replies as before


Made with [Cursor](https://cursor.com)